### PR TITLE
Start restructuring of Attribute subtree

### DIFF
--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -228,15 +228,24 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Reference object <nowiki>[ID is used to a reference object to specify location with respect to.]</nowiki>
 *** State <nowiki>[ID is used to identify a group of events that are changing the state of a variable as for example when the onset means the offset of any other and a change in the state]</nowiki>
 *** Synchronization <nowiki>[ID is used to tag an event for synchronizing data streams.]</nowiki>
-* Onset <nowiki>[Default]</nowiki> 
-* Offset
-* Duration <nowiki>{requireChild} [An offset that is implicit after duration time passed from the onset]</nowiki> 
-** <nowiki># {takesValue, isNumeric, unitClass=time}</nowiki> 
+* Temporal 
+** Duration <nowiki>{requireChild} [An offset that is implicit after duration time passed from the onset]</nowiki>
+*** <nowiki># {takesValue, isNumeric, unitClass=time}</nowiki>
+** Onset <nowiki>[Default]</nowiki> 
+** Offset
+** Repetition <nowiki>{requireChild} [When the same type of event such as a fixation on the exact same object happens multiple times and it might be necessary to distinguish the first look vs. others]</nowiki> 
+*** <nowiki># {takesValue, isNumeric} [Number starting from 1 where 1 indicates the first occurrence and 2 indicates the second occurrence]</nowiki> 
+** Response start delay <nowiki>[The time interval between this (stimulus) event and the start of the response event specified, usually by grouping with the event ID of the response start event.]</nowiki>
+*** <nowiki># {takesValue, unitClass=time}</nowiki>
+** Response end delay <nowiki>[The time interval between this (stimulus) event and the end of the response event specified, usually by grouping with the event ID of the response end event.]</nowiki>
+*** <nowiki># {takesValue, unitClass=time}</nowiki>
+** Temporal rate <nowiki>{predicateType=propertyOf}</nowiki> 
+*** <nowiki># {takesValue, isNumeric, unitClass=frequency} [In Hz]</nowiki> 
+** Temporal uncertainty <nowiki> {requireChild} [Use to specify the amount of uncertainty in the timing of the event. Please notice that this is different from Attribute/Probability tag which relates to the occurrence of event and can be interpretative as the integral of probability density across a distribution whose shape (temporal extent) is specified by Attribute/Temporal uncertainty]. </nowiki> 
+*** <nowiki># {takesValue, isNumeric, unitClass=time} [implies that the temporal uncertainty is a uniform distribution with the amount of time provided, extending on both side. E.g. "0.5 s" specifies a 1-second range centered at event latency.</nowiki> 
+*** Standard deviation <nowiki>{requireChild} [implies that the distribution of temporal uncertainty is Gaussian with the provided standard deviation (in seconds).]</nowiki> 
+**** <nowiki># {takesValue, isNumeric, unitClass=time}</nowiki>
 * Imagined <nowiki>[This is used to identity that the (sub)event only happened in participant's imagination, e.g.  imagined movements in motor imagery paradigms.]</nowiki>
-* Repetition <nowiki>{requireChild} [When the same type of event such as a fixation on the exact same object happens multiple times and it might be necessary to distinguish the first look vs. others]</nowiki> 
-** <nowiki># {takesValue, isNumeric} [Number starting from 1 where 1 indicates the first occurrence and 2 indicates the second occurrence]</nowiki>
-* Temporal rate <nowiki>{predicateType=propertyOf}</nowiki> 
-** <nowiki># {takesValue, isNumeric, unitClass=frequency} [In Hz]</nowiki> 
 * Condition <nowiki>{requireChild} [Specifies the value of an independent variable (number of letters, N, in an N-back task) or function of independent variables that is varied or controlled for in the experiment.  This attribute is often specified at the task level and can be associated with specification of an experimental stimulus or an experiment context (e.g. 1-back, 2-back conditions in an N-back task, or changing the target type from faces to houses in a Rapid Serial Visual Presentation, or RSVP, task.)]</nowiki>
 ** # <nowiki>{takesValue} [the condition]</nowiki> 
 * Action judgment <nowiki>[External judgment (assumed to be ground truth, e.g. from an experiment control software or an annotator) about participant actions such as answering a question, failing to answer in time, etc.]</nowiki> 
@@ -246,10 +255,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Time out 
 *** Missed <nowiki>[Participant failed or could not have perceived the instruction due to their eyes being off-screen or a similar reason. Not easy to deduce this but it is possible]</nowiki> 
 ** Inappropriate <nowiki>[A choice that is not allowed such as moving a chess piece to a location it should not go based on game rules]</nowiki>
-* Response start delay <nowiki>[The time interval between this (stimulus) event and the start of the response event specified, usually by grouping with the event ID of the response start event.]</nowiki>
-** <nowiki># {takesValue, unitClass=time}</nowiki>
-* Response end delay <nowiki>[The time interval between this (stimulus) event and the end of the response event specified, usually by grouping with the event ID of the response end event.]</nowiki>
-** <nowiki># {takesValue, unitClass=time}</nowiki>
+
 * Social <nowiki>[Involving interactions among multiple agents such as humans or dogs or robots]</nowiki> 
 * Peak <nowiki>[Peak velocity or  acceleration or jerk]</nowiki>
 * Object side <nowiki>{requireChild} [Could be the left,  right, or both sides of a person or a vehicle]</nowiki> 
@@ -475,10 +481,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 * Supraliminal <nowiki>[By default this is assumed about each stimulus]</nowiki> 
 * Liminal <nowiki>[At the 75%-25% perception threshold]</nowiki> 
 * Probability <nowiki> [Use to specify the level of certainty about the occurrence of the event. Use either numerical values as the child node or 'low', 'high', etc.]</nowiki> 
-* Temporal uncertainty <nowiki> {requireChild} [Use to specify the amount of uncertainty in the timing of the event. Please notice that this is different from Attribute/Probability tag which relates to the occurrence of event and can be interpretative as the integral of probability density across a distribution whose shape (temporal extent) is specified by Attribute/Temporal uncertainty]. </nowiki> 
-** <nowiki># {takesValue, isNumeric, unitClass=time} [implies that the temporal uncertainty is a uniform distribution with the amount of time provided, extending on both side. E.g. "0.5 s" specifies a 1-second range centered at event latency.</nowiki> 
-** Standard deviation <nowiki>{requireChild} [implies that the distribution of temporal uncertainty is Gaussian with the provided standard deviation (in seconds).]</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=time}</nowiki>
+
 * Presentation <nowiki>{requireChild}[Attributes associated with visual, auditory, tactile, etc. presentation of an stimulus]</nowiki>
 ** Fraction <nowiki>{requireChild} [the fraction of presentation of an Oddball or Expected stimuli to the total number of same-class presentations, e.g. 10% of images in an RSVP being targets] </nowiki> 
 *** <nowiki># {takesValue, isNumeric}</nowiki>

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -263,9 +263,27 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 **** Rightmost 
 **** Right of expected 
 
+*** Real-world coordinates <nowiki>{requireChild}</nowiki> 
+**** Room 
+***** xyz <nowiki> {requireChild} [have a subnode, e.g. Attribute/Location/Real-world coordinates/Room/xyz/[10 50 30]]</nowiki> 
+****** <nowiki># {takesValue}</nowiki> 
 
-
-
+*** Reference frame <nowiki>{requireChild}</nowiki> 
+**** Relative to participant
+***** Azimuth <nowiki>{requireChild}</nowiki> 
+****** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise with units preferably in degrees]</nowiki>  
+***** Back 
+***** Distance <nowiki>{requireChild}</nowiki> 
+****** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} [Distance is in meters by default]</nowiki> 
+****** Far
+****** Moderate  
+****** Near 
+***** Elevation <nowiki>{requireChild}</nowiki> 
+****** <nowiki># {takesValue, isNumeric, unitClass=angle} [Preferably in degrees]</nowiki> 
+***** Front 
+***** Left 
+***** Right 
+**** Specified absolute reference 
 
 *** Screen <nowiki>[Specify displacements from each subnode in pixels or degrees or meters. Specify units such as Attribute/Spatial/Location/Screen/Top/12 px]</nowiki> 
 **** Angle  
@@ -291,27 +309,6 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 
 
 
-
-** Real-world coordinates <nowiki>{requireChild}</nowiki> 
-*** Room 
-**** xyz <nowiki> {requireChild} [have a subnode, e.g. Attribute/Location/Real-world coordinates/Room/xyz/[10 50 30]]</nowiki> 
-***** <nowiki># {takesValue}</nowiki> 
-** Reference frame <nowiki>{requireChild}</nowiki> 
-*** Specified absolute reference 
-*** Relative to participant 
-**** Left 
-**** Front 
-**** Right 
-**** Back 
-**** Distance <nowiki>{requireChild}</nowiki> 
-***** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} [Distance is in meters by default]</nowiki> 
-***** Near 
-***** Moderate 
-***** Far 
-**** Azimuth <nowiki>{requireChild}</nowiki> 
-***** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise with units preferably in degrees]</nowiki> 
-**** Elevation <nowiki>{requireChild}</nowiki> 
-***** <nowiki># {takesValue, isNumeric, unitClass=angle} [Preferably in degrees]</nowiki> 
 
 
 

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -252,6 +252,71 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Forward <nowiki> [Like a car moving forward]</nowiki> 
 *** Backward <nowiki>[Like a car moving backward]</nowiki> 
 
+** Location {requireChild} <nowiki>[Spot or center of an area. Use Area were you are referring to something with significant extent and emphasizing its boundaries, like a city]</nowiki> 
+*** <nowiki># {takesValue} [location label]</nowiki> 
+*** Lane <nowiki>[For example a car lane]</nowiki> 
+**** Cruising  
+**** Leftmost 
+**** Left of expected 
+**** Oncoming 
+**** Passing <nowiki>[The lane that cars use to take over other cars]</nowiki> 
+**** Rightmost 
+**** Right of expected 
+
+
+
+
+
+*** Screen <nowiki>[Specify displacements from each subnode in pixels or degrees or meters. Specify units such as Attribute/Spatial/Location/Screen/Top/12 px]</nowiki> 
+**** Angle  
+***** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise angle in degrees from vertical]</nowiki> 
+**** Bottom 
+***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+**** Center 
+***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki>
+**** Center displacement 
+***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength} [Displacement from screen center, in any direction, in degrees, cm, or other lengths]</nowiki> 
+***** Horizontal 
+****** <nowiki># {takesValue, isNumeric, unitClass=angle,  unitClass=physicalLength} [Displacement from screen center in any direction]</nowiki> 
+***** Vertical 
+****** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength}[Displacement from screen center in any direction]</nowiki>  
+**** Left 
+***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+**** Right  
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+**** Top <nowiki>[You can combine Attribute/Location/Top and Attribute/Location/Left to designate UpperLeft and so on]</nowiki> 
+***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+
+
+
+
+
+
+** Real-world coordinates <nowiki>{requireChild}</nowiki> 
+*** Room 
+**** xyz <nowiki> {requireChild} [have a subnode, e.g. Attribute/Location/Real-world coordinates/Room/xyz/[10 50 30]]</nowiki> 
+***** <nowiki># {takesValue}</nowiki> 
+** Reference frame <nowiki>{requireChild}</nowiki> 
+*** Specified absolute reference 
+*** Relative to participant 
+**** Left 
+**** Front 
+**** Right 
+**** Back 
+**** Distance <nowiki>{requireChild}</nowiki> 
+***** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} [Distance is in meters by default]</nowiki> 
+***** Near 
+***** Moderate 
+***** Far 
+**** Azimuth <nowiki>{requireChild}</nowiki> 
+***** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise with units preferably in degrees]</nowiki> 
+**** Elevation <nowiki>{requireChild}</nowiki> 
+***** <nowiki># {takesValue, isNumeric, unitClass=angle} [Preferably in degrees]</nowiki> 
+
+
+
+
+
 ** Object orientation <nowiki>{requireChild}</nowiki> 
 *** Rotated 
 **** Degrees <nowiki>{requireChild}</nowiki> 
@@ -317,55 +382,6 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 * Social <nowiki>[Involving interactions among multiple agents such as humans or dogs or robots]</nowiki> 
 * Peak <nowiki>[Peak velocity or  acceleration or jerk]</nowiki>
 
-* Location {requireChild} <nowiki>[Spot or center of an area. Use Area were you are referring to something with significant extent and emphasizing its boundaries, like a city]</nowiki> 
-** <nowiki># {takesValue} [location label]</nowiki> 
-** Screen <nowiki>[Specify displacements from each subnode in pixels or degrees or meters. Specify units such as Attribute/Location/Screen/Top/12 px]</nowiki> 
-*** Center 
-**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-*** Top <nowiki>[You can combine Attribute/Location/Top and Attribute/Location/Left to designate UpperLeft and so on]</nowiki> 
-**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-*** Bottom 
-**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-*** Left 
-**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-*** Right  
-**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-*** Angle  
-**** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise angle in degrees from vertical]</nowiki> 
-*** Center displacement 
-**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength} [displacement from screen center, in any direction, in degrees, cm, or other lengths]</nowiki> 
-**** Horizontal 
-***** <nowiki># {takesValue, isNumeric, unitClass=angle,  unitClass=physicalLength} [Displacement from screen center in any direction]</nowiki> 
-**** Vertical 
-***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength}[Displacement from screen center in any direction]</nowiki> 
-** Lane <nowiki>[For example a car lane]</nowiki> 
-*** Rightmost 
-*** Leftmost 
-*** Right of expected 
-*** Left of expected 
-*** Cruising  
-*** Passing <nowiki>[The lane that cars use to take over other cars]</nowiki> 
-*** Oncoming 
-** Real-world coordinates <nowiki>{requireChild}</nowiki> 
-*** Room 
-**** xyz <nowiki> {requireChild} [have a subnode, e.g. Attribute/Location/Real-world coordinates/Room/xyz/[10 50 30]]</nowiki> 
-***** <nowiki># {takesValue}</nowiki> 
-** Reference frame <nowiki>{requireChild}</nowiki> 
-*** Specified absolute reference 
-*** Relative to participant 
-**** Left 
-**** Front 
-**** Right 
-**** Back 
-**** Distance <nowiki>{requireChild}</nowiki> 
-***** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} [Distance is in meters by default]</nowiki> 
-***** Near 
-***** Moderate 
-***** Far 
-**** Azimuth <nowiki>{requireChild}</nowiki> 
-***** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise with units preferably in degrees]</nowiki> 
-**** Elevation <nowiki>{requireChild}</nowiki> 
-***** <nowiki># {takesValue, isNumeric, unitClass=angle} [Preferably in degrees]</nowiki> 
 
 
 * Item count <nowiki>{requireChild} [Number of items for example when there are 3 cars and they are identified as a single item]</nowiki> 

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -251,6 +251,12 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 **** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
 *** Forward <nowiki> [Like a car moving forward]</nowiki> 
 *** Backward <nowiki>[Like a car moving backward]</nowiki> 
+
+** Object orientation <nowiki>{requireChild}</nowiki> 
+*** Rotated 
+**** Degrees <nowiki>{requireChild}</nowiki> 
+***** <nowiki>#{takesValue, isNumeric, unitClass=angle}[Preferably in degrees]</nowiki> 
+
 ** Object side <nowiki>{requireChild} [Could be the left,  right, or both sides of a person or a vehicle]</nowiki> 
 *** Back 
 *** Bottom 
@@ -265,7 +271,20 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Starboard 
 *** Top 
 
-
+** Size <nowiki>{requireChild}</nowiki>
+*** Angle<nowiki>{requireChild}</nowiki> 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle} [In degrees or other units of angle]</nowiki> 
+*** Area <nowiki>{requireChild}</nowiki> 
+**** <nowiki># {takesValue, isNumeric, unitClass=area}</nowiki>
+*** Height
+**** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} [Default units are meters]</nowiki>
+*** Length<nowiki>{requireChild}</nowiki> 
+**** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} [In meters or other units of length ]</nowiki> 
+*** Volume <nowiki>{requireChild}</nowiki> 
+**** <nowiki># {takesValue, isNumeric, unitClass=volume} [In cubic-meters or other units of volume]</nowiki> 
+*** Width
+**** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} </nowiki><nowiki>[in meters]</nowiki> 
+ 
 
 * Temporal <nowiki>{requireChild}</nowiki>
 ** Duration <nowiki>{requireChild} [An offset that is implicit after duration time passed from the onset]</nowiki>
@@ -347,23 +366,8 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ***** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise with units preferably in degrees]</nowiki> 
 **** Elevation <nowiki>{requireChild}</nowiki> 
 ***** <nowiki># {takesValue, isNumeric, unitClass=angle} [Preferably in degrees]</nowiki> 
-* Object orientation <nowiki>{requireChild}</nowiki> 
-** Rotated 
-*** Degrees <nowiki>{requireChild}</nowiki> 
-**** <nowiki>#{takesValue, isNumeric, unitClass=angle}[Preferably in degrees]</nowiki> 
-* Size <nowiki>{requireChild}</nowiki> 
-** Length<nowiki>{requireChild}</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} [In meters or other units of length ]</nowiki> 
-** Width
-*** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} </nowiki><nowiki>[in meters]</nowiki> 
-** Height
-*** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} [Default units are meters]</nowiki> 
-** Area <nowiki>{requireChild}</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=area}</nowiki> 
-** Volume <nowiki>{requireChild}</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=volume} [In cubic-meters or other units of volume]</nowiki> 
-** Angle<nowiki>{requireChild}</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=angle} [In degrees or other units of angle]</nowiki> 
+
+
 * Item count <nowiki>{requireChild} [Number of items for example when there are 3 cars and they are identified as a single item]</nowiki> 
 ** <nowiki># {takesValue, isNumeric} [Numeric value of number of items #]</nowiki> 
 ** <nowiki><=# {takesValue, isNumeric} [Number of items less than or equal to #]</nowiki> 

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -1,4 +1,4 @@
-HED version: v1.0.1-restruct
+HED version: v1.2.0-restruct
 
 '''Syntax'''  
 
@@ -228,7 +228,6 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Reference object <nowiki>[ID is used to a reference object to specify location with respect to.]</nowiki>
 *** State <nowiki>[ID is used to identify a group of events that are changing the state of a variable as for example when the onset means the offset of any other and a change in the state]</nowiki>
 *** Synchronization <nowiki>[ID is used to tag an event for synchronizing data streams.]</nowiki>
-
 * Spatial <nowiki>{requireChild}</nowiki>
 ** Direction <nowiki>{requireChild} [Coordinate system is inferred from Attribute/Location. To specify a vector combine subnodes with number --- for example Attribute/Top/10, Attribute/Direction/Left/5 to create a vector with coordinates 10 and 5]</nowiki> 
 *** Bottom 
@@ -262,12 +261,10 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 **** Passing <nowiki>[The lane that cars use to take over other cars]</nowiki> 
 **** Rightmost 
 **** Right of expected 
-
 *** Real-world coordinates <nowiki>{requireChild}</nowiki> 
 **** Room 
 ***** xyz <nowiki> {requireChild} [have a subnode, e.g. Attribute/Location/Real-world coordinates/Room/xyz/[10 50 30]]</nowiki> 
 ****** <nowiki># {takesValue}</nowiki> 
-
 *** Reference frame <nowiki>{requireChild}</nowiki> 
 **** Relative to participant
 ***** Azimuth <nowiki>{requireChild}</nowiki> 
@@ -284,7 +281,6 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ***** Left 
 ***** Right 
 **** Specified absolute reference 
-
 *** Screen <nowiki>[Specify displacements from each subnode in pixels or degrees or meters. Specify units such as Attribute/Spatial/Location/Screen/Top/12 px]</nowiki> 
 **** Angle  
 ***** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise angle in degrees from vertical]</nowiki> 
@@ -304,21 +300,10 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 **** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
 **** Top <nowiki>[You can combine Attribute/Location/Top and Attribute/Location/Left to designate UpperLeft and so on]</nowiki> 
 ***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-
-
-
-
-
-
-
-
-
-
 ** Object orientation <nowiki>{requireChild}</nowiki> 
 *** Rotated 
 **** Degrees <nowiki>{requireChild}</nowiki> 
 ***** <nowiki>#{takesValue, isNumeric, unitClass=angle}[Preferably in degrees]</nowiki> 
-
 ** Object side <nowiki>{requireChild} [Could be the left,  right, or both sides of a person or a vehicle]</nowiki> 
 *** Back 
 *** Bottom 
@@ -332,7 +317,6 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Stern <nowiki>[Back of the ship]</nowiki>
 *** Starboard 
 *** Top 
-
 ** Size <nowiki>{requireChild}</nowiki>
 *** Angle<nowiki>{requireChild}</nowiki> 
 **** <nowiki># {takesValue, isNumeric, unitClass=angle} [In degrees or other units of angle]</nowiki> 
@@ -346,8 +330,6 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 **** <nowiki># {takesValue, isNumeric, unitClass=volume} [In cubic-meters or other units of volume]</nowiki> 
 *** Width
 **** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} </nowiki><nowiki>[in meters]</nowiki> 
- 
-
 * Temporal <nowiki>{requireChild}</nowiki>
 ** Duration <nowiki>{requireChild} [An offset that is implicit after duration time passed from the onset]</nowiki>
 *** <nowiki># {takesValue, isNumeric, unitClass=time}</nowiki>

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -228,7 +228,46 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Reference object <nowiki>[ID is used to a reference object to specify location with respect to.]</nowiki>
 *** State <nowiki>[ID is used to identify a group of events that are changing the state of a variable as for example when the onset means the offset of any other and a change in the state]</nowiki>
 *** Synchronization <nowiki>[ID is used to tag an event for synchronizing data streams.]</nowiki>
-* Temporal 
+
+* Spatial <nowiki>{requireChild}</nowiki>
+** Direction <nowiki>{requireChild} [Coordinate system is inferred from Attribute/Location. To specify a vector combine subnodes with number --- for example Attribute/Top/10, Attribute/Direction/Left/5 to create a vector with coordinates 10 and 5]</nowiki> 
+*** Bottom 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki>
+*** Left 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+*** Right  
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki>  
+*** Top <nowiki> [Combine Attribute/Direction/Top and Attribute/Direction/Left to mean the upper left]</nowiki> 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+*** Angle <nowiki>[Clockwise angle in degrees from vertical]</nowiki> 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise angle in degrees from vertical]</nowiki> 
+*** North 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+*** South 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+*** East 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+*** West 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+*** Forward <nowiki> [Like a car moving forward]</nowiki> 
+*** Backward <nowiki>[Like a car moving backward]</nowiki> 
+** Object side <nowiki>{requireChild} [Could be the left,  right, or both sides of a person or a vehicle]</nowiki> 
+*** Back 
+*** Bottom 
+*** Bow <nowiki>[Front of a ship]</nowiki> 
+*** Driver side <nowiki>[Side of a car]</nowiki> 
+*** Front 
+*** Left 
+*** Passenger side <nowiki>[Side of a car]</nowiki> 
+*** Port 
+*** Right 
+*** Stern <nowiki>[Back of the ship]</nowiki>
+*** Starboard 
+*** Top 
+
+
+
+* Temporal <nowiki>{requireChild}</nowiki>
 ** Duration <nowiki>{requireChild} [An offset that is implicit after duration time passed from the onset]</nowiki>
 *** <nowiki># {takesValue, isNumeric, unitClass=time}</nowiki>
 ** Onset <nowiki>[Default]</nowiki> 
@@ -258,40 +297,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 
 * Social <nowiki>[Involving interactions among multiple agents such as humans or dogs or robots]</nowiki> 
 * Peak <nowiki>[Peak velocity or  acceleration or jerk]</nowiki>
-* Object side <nowiki>{requireChild} [Could be the left,  right, or both sides of a person or a vehicle]</nowiki> 
-** Right 
-** Left 
-** Front 
-** Back 
-** Top 
-** Bottom 
-** Starboard 
-** Port 
-** Passenger side <nowiki>[Side of a car]</nowiki> 
-** Driver side <nowiki>[Side of a car]</nowiki> 
-** Bow <nowiki>[Front of a ship]</nowiki> 
-** Stern <nowiki>[Back of the ship]</nowiki>
-* Direction <nowiki>{requireChild} [Coordinate system is inferred from Attribute/Location. To specify a vector combine subnodes with number --- for example Attribute/Top/10, Attribute/Direction/Left/5 to create a vector with coordinates 10 and 5]</nowiki> 
-** Top <nowiki> [Combine Attribute/Direction/Top and Attribute/Direction/Left to mean the upper left]</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-** Bottom 
-*** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-** Left 
-*** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-** Right  
-*** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-** Angle <nowiki>[Clockwise angle in degrees from vertical]</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise angle in degrees from vertical]</nowiki> 
-** North 
-*** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-** South 
-*** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-** East 
-*** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-** West 
-*** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-** Forward <nowiki> [Like a car moving forward]</nowiki> 
-** Backward <nowiki>[Like a car moving backward]</nowiki> 
+
 * Location {requireChild} <nowiki>[Spot or center of an area. Use Area were you are referring to something with significant extent and emphasizing its boundaries, like a city]</nowiki> 
 ** <nowiki># {takesValue} [location label]</nowiki> 
 ** Screen <nowiki>[Specify displacements from each subnode in pixels or degrees or meters. Specify units such as Attribute/Location/Screen/Top/12 px]</nowiki> 

--- a/HEDremap.tsv
+++ b/HEDremap.tsv
@@ -31,3 +31,37 @@ Attribute/Response end delay/#	Attribute/Temporal/Response end delay/#
 Attribute/Temporal rate/#	Attribute/Temporal/Temporal rate/#
 Attribute/Temporal uncertainty/#	Attribute/Temporal/Temporal uncertainty/# 
 Attribute/Temporal uncertainty/Standard deviation/#	Attribute/Temporal/Temporal uncertainty/Standard deviation/# 
+Attribute/Direction/Bottom	Attribute/Spatial/Direction/Bottom
+Attribute/Direction/Bottom/#	Attribute/Spatial/Direction/Bottom/#
+Attribute/Direction/Left	Attribute/Spatial/Direction/Left
+Attribute/Direction/Left/#	Attribute/Spatial/Direction/Left/#
+Attribute/Direction/Right	Attribute/Spatial/Direction/Right
+Attribute/Direction/Right/#	Attribute/Spatial/Direction/Right/#
+Attribute/Direction/Top	Attribute/Spatial/Direction/Top
+Attribute/Direction/Top/#	Attribute/Spatial/Direction/Top/#
+Attribute/Direction/Angle	Attribute/Spatial/Direction/Angle
+Attribute/Direction/Angle/#	Attribute/Spatial/Direction/Angle/#
+Attribute/Direction/East	Attribute/Spatial/Direction/East
+Attribute/Direction/East/#	Attribute/Spatial/Direction/East/#
+Attribute/Direction/North	Attribute/Spatial/Direction/North
+Attribute/Direction/North/#	Attribute/Spatial/Direction/North/#
+Attribute/Direction/South	Attribute/Spatial/Direction/South
+Attribute/Direction/South/#	Attribute/Spatial/Direction/South/#
+Attribute/Direction/West	Attribute/Spatial/Direction/West
+Attribute/Direction/West/#	Attribute/Spatial/Direction/West/#
+Attribute/Direction/Bottom	Attribute/Spatial/Direction/Bottom
+Attribute/Direction/Bottom/#	Attribute/Spatial/Direction/Bottom/#
+Attribute/Direction/Forward	Attribute/Spatial/Direction/Forward
+Attribute/Direction/Backward	Attribute/Spatial/Direction/Backward
+Attribute/Object side/Back	Attribute/Spatial/Object side/Back
+Attribute/Object side/Bottom	Attribute/Spatial/Object side/Bottom
+Attribute/Object side/Bow	Attribute/Spatial/Object side/Bow
+Attribute/Object side/Driver side	Attribute/Spatial/Object side/Driver side
+Attribute/Object side/Front	Attribute/Spatial/Object side/Front
+Attribute/Object side/Left	Attribute/Spatial/Object side/Left
+Attribute/Object side/Passenger side	Attribute/Spatial/Object side/Passenger side
+Attribute/Object side/Port	Attribute/Spatial/Object side/Port
+Attribute/Object side/Right	Attribute/Spatial/Object side/Right
+Attribute/Object side/Starboard	Attribute/Spatial/Object side/Starboard
+Attribute/Object side/Stern	Attribute/Spatial/Object side/Stern
+Attribute/Object side/Top	Attribute/Spatial/Object side/Top

--- a/HEDremap.tsv
+++ b/HEDremap.tsv
@@ -22,3 +22,12 @@ Event/Category/Experiment control/Sequence/Trial/#	(Event/Category/Experiment co
 Event/Category/Experiment control/Task/#	(Event/Category/Experiment control/Task, Attribute/ID/Value/#)
 Event/Category/Experiment control/Synchronization/Tag	(Event/Category/Experiment control/Synchronization, Attribute/ID/Type/Synchronization)
 Event/Category/Experiment control/Synchronization/Tag/#	(Event/Category/Experiment control/Synchronization, Attribute/ID/Type/Synchronization, Attribute/ID/Value/#)
+Attribute/Onset	Attribute/Temporal/Onset
+Attribute/Offset	Attribute/Temporal/Offset
+Attribute/Duration/#	Attribute/Temporal/Duration/#
+Attribute/Repetition/#	Attribute/Temporal/Repetition/#
+Attribute/Response start delay/#	Attribute/Temporal/Response start delay/#
+Attribute/Response end delay/#	Attribute/Temporal/Response end delay/#
+Attribute/Temporal rate/#	Attribute/Temporal/Temporal rate/#
+Attribute/Temporal uncertainty/#	Attribute/Temporal/Temporal uncertainty/# 
+Attribute/Temporal uncertainty/Standard deviation/#	Attribute/Temporal/Temporal uncertainty/Standard deviation/# 

--- a/HEDremap.tsv
+++ b/HEDremap.tsv
@@ -55,6 +55,34 @@ Attribute/Direction/Forward	Attribute/Spatial/Direction/Forward
 Attribute/Direction/Backward	Attribute/Spatial/Direction/Backward
 
 Attribute/Location/#	Attribute/Spatial/Location/#
+
+Attribute/Location/Lane	Attribute/Spatial/Location/Lane
+Attribute/Location/Lane/Cruising	Attribute/Spatial/Location/Lane/Cruising
+Attribute/Location/Lane/Leftmost	Attribute/Spatial/Location/Lane/Leftmost
+Attribute/Location/Lane/Left of expected	Attribute/Spatial/Location/Lane/Left of expected
+Attribute/Location/Lane/Oncoming	Attribute/Spatial/Location/Lane/Oncoming
+Attribute/Location/Lane/Passing	Attribute/Spatial/Location/Lane/Passing
+Attribute/Location/Lane/Rightmost	Attribute/Spatial/Location/Lane/Rightmost
+Attribute/Location/Lane/Right of expected	Attribute/Spatial/Location/Lane/Right of expected
+
+Attribute/Location/Reference frame/Relative to participant	Attribute/Spatial/Location/Reference frame/Relative to participant
+Attribute/Location/Reference frame/Relative to participant/Azimuth/#	Attribute/Spatial/Location/Reference frame/Relative to participant/Azimuth/#
+Attribute/Location/Reference frame/Relative to participant/Back	Attribute/Spatial/Location/Reference frame/Relative to participant/Back
+Attribute/Location/Reference frame/Relative to participant/Distance/#	Attribute/Spatial/Location/Reference frame/Relative to participant/Distance/#
+Attribute/Location/Reference frame/Relative to participant/Distance/Far	Attribute/Spatial/Location/Reference frame/Relative to participant/Distance/Far
+Attribute/Location/Reference frame/Relative to participant/Distance/Moderate	Attribute/Spatial/Location/Reference frame/Relative to participant/Distance/Moderate
+Attribute/Location/Reference frame/Relative to participant/Near	Attribute/Spatial/Location/Reference frame/Relative to participant/Near
+Attribute/Location/Reference frame/Relative to participant/Elevation/#	Attribute/Spatial/Location/Reference frame/Relative to participant/Elevation/#
+Attribute/Location/Reference frame/Relative to participant/Front	Attribute/Spatial/Location/Reference frame/Relative to participant/Front
+Attribute/Location/Reference frame/Relative to participant/Left	Attribute/Spatial/Location/Reference frame/Relative to participant/Left
+Attribute/Location/Reference frame/Relative to participant/Right	Attribute/Spatial/Location/Reference frame/Relative to participant/Right
+
+Attribute/Location/Reference frame/Specified absolute reference	Attribute/Spatial/Location/Reference frame/Specified absolute reference
+
+Attribute/Location/Reference frame	Attribute/Spatial/Location/Reference frame
+
+Attribute/Location/Real-world coordinates/Room/xyz/#	Attribute/Spatial/Location/Real-world coordinates/Room/xyz/#
+
 Attribute/Location/Screen	Attribute/Spatial/Location/Screen
 Attribute/Location/Screen/Angle	Attribute/Spatial/Location/Screen/Angle
 Attribute/Location/Screen/Angle/#	Attribute/Spatial/Location/Screen/Angle/#

--- a/HEDremap.tsv
+++ b/HEDremap.tsv
@@ -65,3 +65,12 @@ Attribute/Object side/Right	Attribute/Spatial/Object side/Right
 Attribute/Object side/Starboard	Attribute/Spatial/Object side/Starboard
 Attribute/Object side/Stern	Attribute/Spatial/Object side/Stern
 Attribute/Object side/Top	Attribute/Spatial/Object side/Top
+Attribute/Object orientation/Rotated	Attribute/Spatial/Object orientation/Rotated
+Attribute/Object orientation/Rotated/Degrees/#	Attribute/Spatial/Object orientation/Rotated/Degrees/#
+
+Attribute/Size/Angle/#	Attribute/Spatial/Size/Angle/#
+Attribute/Size/Area/#	Attribute/Spatial/Size/Area/#
+Attribute/Size/Height/#	Attribute/Spatial/Size/Height/#
+Attribute/Size/Length/#	Attribute/Spatial/Size/Length/#
+Attribute/Size/Volume/#	Attribute/Spatial/Size/Volume/#
+Attribute/Size/Width/#	Attribute/Spatial/Size/Width/#

--- a/HEDremap.tsv
+++ b/HEDremap.tsv
@@ -53,6 +53,33 @@ Attribute/Direction/Bottom	Attribute/Spatial/Direction/Bottom
 Attribute/Direction/Bottom/#	Attribute/Spatial/Direction/Bottom/#
 Attribute/Direction/Forward	Attribute/Spatial/Direction/Forward
 Attribute/Direction/Backward	Attribute/Spatial/Direction/Backward
+
+Attribute/Location/#	Attribute/Spatial/Location/#
+Attribute/Location/Screen	Attribute/Spatial/Location/Screen
+Attribute/Location/Screen/Angle	Attribute/Spatial/Location/Screen/Angle
+Attribute/Location/Screen/Angle/#	Attribute/Spatial/Location/Screen/Angle/#
+Attribute/Location/Screen/Bottom	Attribute/Spatial/Location/Screen/Bottom
+Attribute/Location/Screen/Bottom/#	Attribute/Spatial/Location/Screen/Bottom/#
+Attribute/Location/Screen/Center	Attribute/Spatial/Location/Screen/Center
+Attribute/Location/Screen/Center/#	Attribute/Spatial/Location/Screen/Center/#
+Attribute/Location/Screen/Center displacement	Attribute/Spatial/Location/Screen/Center displacement
+Attribute/Location/Screen/Center displacement/#	Attribute/Spatial/Location/Screen/Center displacement/#
+Attribute/Location/Screen/Center displacement/Horizontal	Attribute/Spatial/Location/Screen/Center displacement/Horizontal
+Attribute/Location/Screen/Center displacement/Horizontal/#	Attribute/Spatial/Location/Screen/Center displacement/Horizontal/#
+Attribute/Location/Screen/Center displacement/Vertical	Attribute/Spatial/Location/Screen/Center displacement/Vertical
+Attribute/Location/Screen/Center displacement/Vertical/#	Attribute/Spatial/Location/Screen/Center displacement/Vertical/#
+Attribute/Location/Screen/Left	Attribute/Spatial/Location/Screen/Left
+Attribute/Location/Screen/Left/#	Attribute/Spatial/Location/Screen/Left/#
+Attribute/Location/Screen/Right	Attribute/Spatial/Location/Screen/Right
+Attribute/Location/Screen/Right/#	Attribute/Spatial/Location/Screen/Right/#
+Attribute/Location/Screen/Top	Attribute/Spatial/Location/Screen/Top
+Attribute/Location/Screen/Top/#	Attribute/Spatial/Location/Screen/Top/#
+
+
+
+Attribute/Object orientation/Rotated	Attribute/Spatial/Object orientation/Rotated
+Attribute/Object orientation/Rotated/Degrees/#	Attribute/Spatial/Object orientation/Rotated/Degrees/#
+
 Attribute/Object side/Back	Attribute/Spatial/Object side/Back
 Attribute/Object side/Bottom	Attribute/Spatial/Object side/Bottom
 Attribute/Object side/Bow	Attribute/Spatial/Object side/Bow
@@ -65,8 +92,7 @@ Attribute/Object side/Right	Attribute/Spatial/Object side/Right
 Attribute/Object side/Starboard	Attribute/Spatial/Object side/Starboard
 Attribute/Object side/Stern	Attribute/Spatial/Object side/Stern
 Attribute/Object side/Top	Attribute/Spatial/Object side/Top
-Attribute/Object orientation/Rotated	Attribute/Spatial/Object orientation/Rotated
-Attribute/Object orientation/Rotated/Degrees/#	Attribute/Spatial/Object orientation/Rotated/Degrees/#
+
 
 Attribute/Size/Angle/#	Attribute/Spatial/Size/Angle/#
 Attribute/Size/Area/#	Attribute/Spatial/Size/Area/#

--- a/README.md
+++ b/README.md
@@ -30,3 +30,58 @@ This file two-column, tab-separated file lists the replacement for tags in HED2 
 
 **Example 1:**  
 Event/ID/3	(Event, Attribute/ID/3)
+
+
+#### General procedure for releases
+
+Tags and releases are not part of the ordinary github commit process.  We are doing these releases so that developers of the validators and converters can develop new code without disturbing the existing infrastructure. These will later be merged when the restructuring process is complete.
+
+
+##### Versioning of the developing infrastructure
+The auto-changelog and other things assume adherence to semantic versioning.  We have two distinct development branches that are in process:  
+   1.  HEDVx.y.z-restruct is being developed on the HED-restructure branch and consists of restructuring the HED schema without modifying the validators and parsers.
+   2.  HEDVx.y.z.-devunit is being developed to better handle SI units as well as multiples and submultiples so that it will be compatible with BIDS.
+
+The procedures described below are only for the transition well HED is being restructured.  The current version of HED as supported by BIDS and the online HED validator has not changed and is in the master branch of this repository.
+
+##### Merge process
+Update process:  
+   1.  Fork the HED-restructure branch of the hed-standard/hed-specification repository to your github account.  
+   2.  To avoid confusion, I have been renaming this repository hed-specification-working in my account.  
+   3.  Clone this repository locally to make your changes and then push to your working repository.
+   4.  When you are done, do a pull request for hed-specification-working to the actual repository on hed-standard.  Be sure to indicate whether this is a change that is patch level, minor, or major. Make sure that Nima, Dung, and Kay are reviewers of the pull request.
+   5.  When all reviewers have approved, the request is merged.  
+
+##### Adding annotated tags to define the version
+After a fork has been merged, Kay will create a new release so that we can control testing.  This is the process:  
+    1. Clone hed-standard/hed-specification (HED-restructure) locally.
+    2. Add an annotated tag with the new version that is associated with the merge commit:: 
+```
+git tag -a v1.2.1-restruct   fe03asg  -m "Release v1.1.0-restruct removes IDs from non Attribute subtrees"
+```
+The `fe03asg` is the leading part of the hash string for the commit that we are going to associate a new version number with. Now we have to push the tag to github since the tags are stored separately from the respository:
+
+```
+git push origin --tags
+```
+
+##### Create the new release on github
+Once this is done, Kay will create a release associated with this tag on github.  This is done through the GUI on github.
+
+##### Generate the changelog:
+At this point, we will generate a final change log for this release using auto-changelog.  This is an npm module.
+
+  1.  Clone the HED-restructure branch of the hed-standard/hed-specification repository to your local machine.  
+  2.  In the top level directory of the repository, execute the following:  
+```
+auto-changelog --commit-limit false --sort-commits date-desc
+```
+
+  3.  Edit the CHANGELOG.md that is created to make sure everything is in order.  
+  4.  Commit locally and push to the HED-restructure branch of hed-standard/hed-specification.
+  
+
+**NOTE:** The only time we should be directly pushing to hed-standard/hed-specification is during the version/CHANGELOG process.   
+
+Eventually we might look into continuous integration.
+


### PR DESCRIPTION
This pull request moves many of the temporal and spatial attributes under Attribute/Temporal and Attribute/Spatial respectively.  It partially addressed issue #39.

I am making this pull request so that we can generate XML and test that the validators don't break under these changes.