### PR TITLE
Event reorganization and short working outline

### DIFF
--- a/HED-schema-reduced.mediawiki
+++ b/HED-schema-reduced.mediawiki
@@ -40,7 +40,6 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki> 
 *** Technical error <nowiki> {extensionAllowed} [Experimenters forgot to turn on something or the cord snagged and something may be wrong with the data.]</nowiki> 
 *** Informational <nowiki>{extensionAllowed} [Events that are only have informational value and cannot be put in other event categories.]</nowiki> 
-
 * Description <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=3}[Same as HED 1.0 description for human-readable text]</nowiki> 
 ** <nowiki># {takesValue}</nowiki> 
 * Label <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=0} [A label for the event that is less than 20 characters. For example /Label/Accept button. Please note that the information under this tag is primarily not for use in the analysis and is provided for the convenience in referring to events in the context of a single study. Please use Custom tag to define custom event hierarchies. Please do not mention the words Onset or Offset in the label. These should only be placed in Attribute/Temporal/Onset  and Attribute/Temporal/Offset.  Software automatically generates a final label with (onset) or (offset) in parentheses added to the original label. This makes it easier to automatically find onsets and offsets for the same event.]</nowiki> 
@@ -81,9 +80,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Movie
 
 
-
 '''Sensory presentation''' <nowiki>{extensionAllowed} [Object manifestation]</nowiki> 
-
 * Auditory <nowiki>[Sound]</nowiki> 
 ** ABR <nowiki>[Auditory Brainstem Response]</nowiki> 
 ** Tone 
@@ -103,110 +100,9 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Nonvocal <nowiki> [A car engine or gears grinding --- anything that is not made by a human or an animal]</nowiki> 
 *** Engine 
 
-'''Attribute''' <nowiki>{requireChild, extensionAllowed}</nowiki>
-* ID <nowiki>{requireChild}[Tag to identify any aspect of an event. Use parentheses to group an ID Value tag with an ID Type tag to qualify the kind of ID that the value represents.]</nowiki>
-* Parameters <nowiki>{predicateType=propertyOf}</nowiki> 
-**<nowiki># {takesValue} [Experiment parameters in some a string. Do not used quotes.]</nowiki> 
-* Sensory presentation <nowiki>{requireChild}[Object manifestation]</nowiki>
-** Auditory
-** Olfactory
-** Tactile
-** Taste
-** Visual
-*** Rendering type <nowiki>{requireChild, predicateType=passThrough}</nowiki> 
-* Spatial <nowiki>{requireChild}</nowiki>
-** Direction <nowiki>{requireChild} [Coordinate system is inferred from Attribute/Location. To specify a vector combine subnodes with number --- for example Attribute/Top/10, Attribute/Direction/Left/5 to create a vector with coordinates 10 and 5]</nowiki> 
-** Location {requireChild} <nowiki>[Spot or center of an area. Use Area were you are referring to something with significant extent and emphasizing its boundaries, like a city]</nowiki> 
-** Size <nowiki>{requireChild}</nowiki>
-* Temporal <nowiki>{requireChild}</nowiki>
-** Duration <nowiki>{requireChild} [An offset that is implicit after duration time passed from the onset]</nowiki>
-** Onset <nowiki>[Default]</nowiki> 
-** Offset
-** Repetition <nowiki>{requireChild} [When the same type of event such as a fixation on the exact same object happens multiple times and it might be necessary to distinguish the first look vs. others]</nowiki> 
-** Response start delay <nowiki>[The time interval between this (stimulus) event and the start of the response event specified, usually by grouping with the event ID of the response start event.]</nowiki>
-** Response end delay <nowiki>[The time interval between this (stimulus) event and the end of the response event specified, usually by grouping with the event ID of the response end event.]</nowiki>
-** Rate <nowiki>[Number of occurrences in a unit of time.]</nowiki> 
-** Uncertainty <nowiki> {requireChild} [Use to specify the amount of uncertainty in the timing of the event. Please notice that this is different from Attribute/Probability tag which relates to the occurrence of event and can be interpretative as the integral of probability density across a distribution whose shape (temporal extent) is specified by Attribute/Temporal uncertainty]. </nowiki> 
-* Imagined <nowiki>[This is used to identity that the (sub)event only happened in participant's imagination, e.g.  imagined movements in motor imagery paradigms.]</nowiki>
-* Condition <nowiki>{requireChild} [Specifies the value of an independent variable (number of letters, N, in an N-back task) or function of independent variables that is varied or controlled for in the experiment.  This attribute is often specified at the task level and can be associated with specification of an experimental stimulus or an experiment context (e.g. 1-back, 2-back conditions in an N-back task, or changing the target type from faces to houses in a Rapid Serial Visual Presentation, or RSVP, task.)]</nowiki>
-** # <nowiki>{takesValue} [the condition]</nowiki> 
-* Action judgment <nowiki>[External judgment (assumed to be ground truth, e.g. from an experiment control software or an annotator) about participant actions such as answering a question, failing to answer in time, etc.]</nowiki> 
-** Correct 
-** Incorrect <nowiki>[Wrong choice but not time out]</nowiki> 
-** Indeterminate <nowiki>[It cannot be determined that the action was correct or incorrect.]</nowiki> 
-** Time out 
-*** Missed <nowiki>[Participant failed or could not have perceived the instruction due to their eyes being off-screen or a similar reason. Not easy to deduce this but it is possible]</nowiki> 
-** Inappropriate <nowiki>[A choice that is not allowed such as moving a chess piece to a location it should not go based on game rules]</nowiki>
-* Social <nowiki>[Involving interactions among multiple agents such as humans or dogs or robots]</nowiki> 
-* Peak <nowiki>[Peak velocity or  acceleration or jerk]</nowiki>
-* Item count <nowiki>{requireChild} [Number of items for example when there are 3 cars and they are identified as a single item]</nowiki> 
-* Auditory <nowiki></nowiki> 
-** Frequency <nowiki>{requireChild}</nowiki> 
-** Loudness <nowiki>{requireChild}</nowiki> 
-** Ramp up <nowiki>[Increasing in amplitude]</nowiki> 
-** Ramp down <nowiki>[Decreasing in amplitude]</nowiki> 
-* Blink
-** Time shut <nowiki>{requireChild} [The amount of time the eyelid remains closed (typically measured as 90% of the blink amplitude), in seconds.]</nowiki> *** <nowiki># {takesValue, isNumeric, unitClass=time, default=s}</nowiki> 
-** Duration <nowiki>{requireChild} [Duration of blink, usually the half-height blink duration in seconds taken either from base or zero of EEG signal. For eye-trackers, usually denotes interval when pupil covered by eyelid.]</nowiki>***<nowiki># {takesValue, isNumeric, unitClass=time, default=s}</nowiki> 
-** PAVR <nowiki>{requireChild} [Amplitude-Velocity ratio, in centiseconds]</nowiki> *** <nowiki># {takesValue, isNumeric, unitClass=time, default=centiseconds}</nowiki> 
-** NAVR <nowiki>{requireChild} [Negative Amplitude-Velocity ratio, in centiseconds]</nowiki> *** <nowiki># {takesValue, isNumeric, unitClass=time, default=centiseconds}</nowiki>
-* Visual <nowiki></nowiki>
-** Bistable 
-** Background 
-** Foreground 
-** Up-down separated <nowiki>[Stimuli presented both at the top and the bottom of fovea]</nowiki> 
-** Bilateral <nowiki>[For bilateral visual field stimulus presentations]</nowiki> 
-** Motion 
-** Fixation point 
-** Luminance <nowiki>{requireChild}</nowiki> 
-** Color <nowiki>{requireChild}</nowiki> 
 
-* Nonlinguistic <nowiki>[Something that conveys meaning without using words such as the iconic pictures of a man or a woman on the doors of restrooms. Another example is a deer crossing sign with just a picture of jumping deer.]</nowiki> 
-* Semantic <nowiki>[Like in priming or in congruence]</nowiki> 
-* Language 
-** Unit <nowiki>{predicateType=passThrough}</nowiki> 
-** Family <nowiki>{predicateType=passThrough}</nowiki> 
 
-* Induced <nowiki>[Such as inducing emotions or keeping someone awake or in a coma with an external intervention]</nowiki> 
-* Emotional 
-** Arousal <nowiki>[Only in the context of 2D emotion representation]</nowiki> 
-** Positive valence <nowiki> [Valence by itself can be the name of an emotion such as sadness so this tag distinguishes the type of emotion]</nowiki> 
-** Negative valence 
-* Priming 
-** Motoric 
-** Emotional 
-** Perceptual
-* Subliminal 
-** Unmasked 
-** Masked 
-* Supraliminal <nowiki>[By default this is assumed about each stimulus]</nowiki> 
-* Liminal <nowiki>[At the 75%-25% perception threshold]</nowiki> 
-* Probability <nowiki> [Use to specify the level of certainty about the occurrence of the event. Use either numerical values as the child node or 'low', 'high', etc.]</nowiki> 
-* Presentation <nowiki>{requireChild}[Attributes associated with visual, auditory, tactile, etc. presentation of an stimulus]</nowiki>
-** Fraction <nowiki>{requireChild} [the fraction of presentation of an Oddball or Expected stimuli to the total number of same-class presentations, e.g. 10% of images in an RSVP being targets] </nowiki> 
-** Cued <nowiki>[what is presented is cued to the presentation of something else] </nowiki> 
-** Background <nowiki>[presented in the background such as background music, background image, etc. The main factor here is that background presentations are to be ignored, e.g. ignore math question auditory stimuli.] </nowiki>
-* Intended effect <nowiki>[This tag is to be grouped with Participant/Effect/Cognitive to specify the intended cognitive effect (of the experimenter). This is to differentiate the resulting group with Participant/Effect which specifies the actual effect on the participant. For example, in an RSVP experiment if an image is intended to be perceived as a target, (Participant/Effect/Cognitive/Target, Attribute/Intended effect) group is added. If the image was perceived by the subject as a target (e.g. they pressed a button to indicate so), then the tag Participant/Effect/Cognitive/Target is also added: Participant/Effect/Cognitive/Target, (Participant/Effect/Cognitive/Target, Attribute/Intended effect). otherwise the Participant/Effect/Cognitive/Target tag is not included outside of the group.]</nowiki>
-* Instruction <nowiki> [This tag is placed in events of type Event/Category/Experimental stimulus/Instruction, grouped with one or more Action/ tags to replace the detailed specification XXX in Event/Category/Experimental stimulus/Instruction/XXX) in previous versions. Usage example:  Event/Category/Experimental stimulus/Instruction, (Action/Fixate, Attribute/Instruction) ]</nowiki>
-* Participant indication <nowiki> [This tag is placed in events of type Event/Category/Participant response and grouped with Participant/Effect/Cognitive/.. tags to specify the type of cognitive effect the participant has experienced. For example, in an RSVP paradigm, the subject can indicate the detection of a target with a button press. The HED string associated with this button press must include (Attribute/Participant indication, Participant/Effect/Cognitive/Target,...)]</nowiki>
-* Path <nowiki>{requireChild}</nowiki> 
-** Velocity  <nowiki>[Use Attribute/Temporal/Onset or Attribute/Temporal/Offset to specify onset or offset]</nowiki> 
-** Acceleration 
-** Jerk 
-** Constrained <nowiki>[For example a path cannot cross some region]</nowiki> 
-* File <nowiki>{requireChild} [File attributes]</nowiki> 
-** Name 
-** Size 
-** Number
-* Object control <nowiki>{requireChild} [Specifies control such as for a vehicle]</nowiki> 
-* Association <nowiki>{requireChild}</nowiki> 
-** Another person <nowiki>[Item such as a cup belonging to another person]</nowiki> 
-** Same person <nowiki>[Item such as a cup belonging to the participant]</nowiki> 
-* Extraneous <nowiki>[Button presses that are not meaningful for example due to intrinsic mechanical causes after a meaningful press]</nowiki>
-* Role <nowiki> {requireChild} [The role of the agent (participant, character, AI..)]</nowiki> 
-** Leader 
-** Follower 
-** <nowiki># {takesValue}</nowiki> 
+
 
 '''Action'''<nowiki>{extensionAllowed}[May or may not be associated with a prior stimulus.]</nowiki> 
 * Involuntary <nowiki>[Like sneezing or tripping on something or hiccuping]</nowiki> 
@@ -262,16 +158,12 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Intermodal <nowiki>[Between modalities such as changing from audio to visual]</nowiki> 
 *** From modality 
 *** To modality 
-
 * Walk 
 ** Stride <nowiki>[Use onset and offset attributes to indicate different walking stride stages]</nowiki> 
 ** Faster <nowiki>[increasing the speed of walking]</nowiki> 
 ** Slower <nowiki>[decreasing the speed of walking]</nowiki> 
 * Control vehicle <nowiki>[Controlling an object that you are aboard]</nowiki> 
 ** Drive <nowiki>[Driving a vehicle such as a car]</nowiki> 
-*** Correct <nowiki>[Correct for a perturbation]</nowiki> 
-*** Near miss 
-*** Collide 
 ** Stop <nowiki>[Brake a car]</nowiki> 
 ** Pilot <nowiki>[Pilot a vehicle such as an airplane]</nowiki> 
 * Teleoperate <nowiki>[Control an object that you are not aboard]</nowiki> 
@@ -339,7 +231,6 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Taste 
 ** Smell 
 ** Body part 
-
 * State <nowiki>{requireChild}</nowiki> 
 ** Level of consciousness <nowiki>{requireChild}</nowiki> 
 *** Awake 
@@ -384,6 +275,110 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Passive <nowiki>[There is a stimulus presentation but no behavioral measurements are collected from the subject. Subject is instructed not to make any behavioral outputs for example when told to carefully watch/listen/sense. The resting state is not considered passive.]</nowiki> 
 ** Resting <nowiki>[State when there is no stimulus presentation and no behavioral outputs]</nowiki> 
 ** Attention 
+
+
+'''Attribute''' <nowiki>{requireChild, extensionAllowed}</nowiki>
+* ID <nowiki>{requireChild}[Tag to identify any aspect of an event. Use parentheses to group an ID Value tag with an ID Type tag to qualify the kind of ID that the value represents.]</nowiki>
+* Parameters <nowiki>{predicateType=propertyOf}</nowiki> 
+**<nowiki># {takesValue} [Experiment parameters in some a string. Do not used quotes.]</nowiki> 
+* Sensory presentation <nowiki>{requireChild}[Object manifestation]</nowiki>
+** Auditory
+** Olfactory
+** Tactile
+** Taste
+** Visual
+*** Rendering type <nowiki>{requireChild, predicateType=passThrough}</nowiki> 
+* Spatial <nowiki>{requireChild}</nowiki>
+** Direction <nowiki>{requireChild} [Coordinate system is inferred from Attribute/Location. To specify a vector combine subnodes with number --- for example Attribute/Top/10, Attribute/Direction/Left/5 to create a vector with coordinates 10 and 5]</nowiki> 
+** Location {requireChild} <nowiki>[Spot or center of an area. Use Area were you are referring to something with significant extent and emphasizing its boundaries, like a city]</nowiki> 
+** Size <nowiki>{requireChild}</nowiki>
+* Temporal <nowiki>{requireChild}</nowiki>
+** Duration <nowiki>{requireChild} [An offset that is implicit after duration time passed from the onset]</nowiki>
+** Onset <nowiki>[Default]</nowiki> 
+** Offset
+** Repetition <nowiki>{requireChild} [When the same type of event such as a fixation on the exact same object happens multiple times and it might be necessary to distinguish the first look vs. others]</nowiki> 
+** Response start delay <nowiki>[The time interval between this (stimulus) event and the start of the response event specified, usually by grouping with the event ID of the response start event.]</nowiki>
+** Response end delay <nowiki>[The time interval between this (stimulus) event and the end of the response event specified, usually by grouping with the event ID of the response end event.]</nowiki>
+** Rate <nowiki>[Number of occurrences in a unit of time.]</nowiki> 
+** Uncertainty <nowiki> {requireChild} [Use to specify the amount of uncertainty in the timing of the event. Please notice that this is different from Attribute/Probability tag which relates to the occurrence of event and can be interpretative as the integral of probability density across a distribution whose shape (temporal extent) is specified by Attribute/Temporal uncertainty]. </nowiki> 
+* Imagined <nowiki>[This is used to identity that the (sub)event only happened in participant's imagination, e.g.  imagined movements in motor imagery paradigms.]</nowiki>
+* Condition <nowiki>{requireChild} [Specifies the value of an independent variable (number of letters, N, in an N-back task) or function of independent variables that is varied or controlled for in the experiment.  This attribute is often specified at the task level and can be associated with specification of an experimental stimulus or an experiment context (e.g. 1-back, 2-back conditions in an N-back task, or changing the target type from faces to houses in a Rapid Serial Visual Presentation, or RSVP, task.)]</nowiki>
+** # <nowiki>{takesValue} [the condition]</nowiki> 
+* Action judgment <nowiki>[External judgment (assumed to be ground truth, e.g. from an experiment control software or an annotator) about participant actions such as answering a question, failing to answer in time, etc.]</nowiki> 
+** Correct 
+** Incorrect <nowiki>[Wrong choice but not time out]</nowiki> 
+** Indeterminate <nowiki>[It cannot be determined that the action was correct or incorrect.]</nowiki> 
+** Time out 
+*** Missed <nowiki>[Participant failed or could not have perceived the instruction due to their eyes being off-screen or a similar reason. Not easy to deduce this but it is possible]</nowiki> 
+** Inappropriate <nowiki>[A choice that is not allowed such as moving a chess piece to a location it should not go based on game rules]</nowiki>
+* Social <nowiki>[Involving interactions among multiple agents such as humans or dogs or robots]</nowiki> 
+* Peak <nowiki>[Peak velocity or  acceleration or jerk]</nowiki>
+* Item count <nowiki>{requireChild} [Number of items for example when there are 3 cars and they are identified as a single item]</nowiki> 
+* Auditory <nowiki></nowiki> 
+** Frequency <nowiki>{requireChild}</nowiki> 
+** Loudness <nowiki>{requireChild}</nowiki> 
+** Ramp up <nowiki>[Increasing in amplitude]</nowiki> 
+** Ramp down <nowiki>[Decreasing in amplitude]</nowiki> 
+* Blink
+** Time shut <nowiki>{requireChild} [The amount of time the eyelid remains closed (typically measured as 90% of the blink amplitude), in seconds.]</nowiki> *** <nowiki># {takesValue, isNumeric, unitClass=time, default=s}</nowiki> 
+** Duration <nowiki>{requireChild} [Duration of blink, usually the half-height blink duration in seconds taken either from base or zero of EEG signal. For eye-trackers, usually denotes interval when pupil covered by eyelid.]</nowiki>***<nowiki># {takesValue, isNumeric, unitClass=time, default=s}</nowiki> 
+** PAVR <nowiki>{requireChild} [Amplitude-Velocity ratio, in centiseconds]</nowiki> *** <nowiki># {takesValue, isNumeric, unitClass=time, default=centiseconds}</nowiki> 
+** NAVR <nowiki>{requireChild} [Negative Amplitude-Velocity ratio, in centiseconds]</nowiki> *** <nowiki># {takesValue, isNumeric, unitClass=time, default=centiseconds}</nowiki>
+* Visual <nowiki></nowiki>
+** Bistable 
+** Background 
+** Foreground 
+** Up-down separated <nowiki>[Stimuli presented both at the top and the bottom of fovea]</nowiki> 
+** Bilateral <nowiki>[For bilateral visual field stimulus presentations]</nowiki> 
+** Motion 
+** Fixation point 
+** Luminance <nowiki>{requireChild}</nowiki> 
+** Color <nowiki>{requireChild}</nowiki> 
+* Nonlinguistic <nowiki>[Something that conveys meaning without using words such as the iconic pictures of a man or a woman on the doors of restrooms. Another example is a deer crossing sign with just a picture of jumping deer.]</nowiki> 
+* Semantic <nowiki>[Like in priming or in congruence]</nowiki> 
+* Language 
+** Unit <nowiki>{predicateType=passThrough}</nowiki> 
+** Family <nowiki>{predicateType=passThrough}</nowiki> 
+* Induced <nowiki>[Such as inducing emotions or keeping someone awake or in a coma with an external intervention]</nowiki> 
+* Emotional 
+** Arousal <nowiki>[Only in the context of 2D emotion representation]</nowiki> 
+** Positive valence <nowiki> [Valence by itself can be the name of an emotion such as sadness so this tag distinguishes the type of emotion]</nowiki> 
+** Negative valence 
+* Priming 
+** Motoric 
+** Emotional 
+** Perceptual
+* Subliminal 
+** Unmasked 
+** Masked 
+* Supraliminal <nowiki>[By default this is assumed about each stimulus]</nowiki> 
+* Liminal <nowiki>[At the 75%-25% perception threshold]</nowiki> 
+* Probability <nowiki> [Use to specify the level of certainty about the occurrence of the event. Use either numerical values as the child node or 'low', 'high', etc.]</nowiki> 
+* Presentation <nowiki>{requireChild}[Attributes associated with visual, auditory, tactile, etc. presentation of an stimulus]</nowiki>
+** Fraction <nowiki>{requireChild} [the fraction of presentation of an Oddball or Expected stimuli to the total number of same-class presentations, e.g. 10% of images in an RSVP being targets] </nowiki> 
+** Cued <nowiki>[what is presented is cued to the presentation of something else] </nowiki> 
+** Background <nowiki>[presented in the background such as background music, background image, etc. The main factor here is that background presentations are to be ignored, e.g. ignore math question auditory stimuli.] </nowiki>
+* Intended effect <nowiki>[This tag is to be grouped with Participant/Effect/Cognitive to specify the intended cognitive effect (of the experimenter). This is to differentiate the resulting group with Participant/Effect which specifies the actual effect on the participant. For example, in an RSVP experiment if an image is intended to be perceived as a target, (Participant/Effect/Cognitive/Target, Attribute/Intended effect) group is added. If the image was perceived by the subject as a target (e.g. they pressed a button to indicate so), then the tag Participant/Effect/Cognitive/Target is also added: Participant/Effect/Cognitive/Target, (Participant/Effect/Cognitive/Target, Attribute/Intended effect). otherwise the Participant/Effect/Cognitive/Target tag is not included outside of the group.]</nowiki>
+* Instruction <nowiki> [This tag is placed in events of type Event/Category/Experimental stimulus/Instruction, grouped with one or more Action/ tags to replace the detailed specification XXX in Event/Category/Experimental stimulus/Instruction/XXX) in previous versions. Usage example:  Event/Category/Experimental stimulus/Instruction, (Action/Fixate, Attribute/Instruction) ]</nowiki>
+* Participant indication <nowiki> [This tag is placed in events of type Event/Category/Participant response and grouped with Participant/Effect/Cognitive/.. tags to specify the type of cognitive effect the participant has experienced. For example, in an RSVP paradigm, the subject can indicate the detection of a target with a button press. The HED string associated with this button press must include (Attribute/Participant indication, Participant/Effect/Cognitive/Target,...)]</nowiki>
+* Path <nowiki>{requireChild}</nowiki> 
+** Velocity  <nowiki>[Use Attribute/Temporal/Onset or Attribute/Temporal/Offset to specify onset or offset]</nowiki> 
+** Acceleration 
+** Jerk 
+** Constrained <nowiki>[For example a path cannot cross some region]</nowiki> 
+* File <nowiki>{requireChild} [File attributes]</nowiki> 
+** Name 
+** Size 
+** Number
+* Object control <nowiki>{requireChild} [Specifies control such as for a vehicle]</nowiki> 
+* Association <nowiki>{requireChild}</nowiki> 
+** Another person <nowiki>[Item such as a cup belonging to another person]</nowiki> 
+** Same person <nowiki>[Item such as a cup belonging to the participant]</nowiki> 
+* Extraneous <nowiki>[Button presses that are not meaningful for example due to intrinsic mechanical causes after a meaningful press]</nowiki>
+* Role <nowiki> {requireChild} [The role of the agent (participant, character, AI..)]</nowiki> 
+** Leader 
+** Follower 
+** <nowiki># {takesValue}</nowiki> 
 
 
 '''Experiment context''' <nowiki>{extensionAllowed} [Describes the context of the whole experiment or large portions of it and also includes tags that are common across all events]</nowiki> 

--- a/HED-schema-reduced.mediawiki
+++ b/HED-schema-reduced.mediawiki
@@ -17,7 +17,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Incidental {extensionAllowed} <nowiki>[A non-task-related action taken by the participant -- for example yawning, standing up during a seated experiment, or responding to a loud noise unrelated to the experiment.]</nowiki>
 ** Data feature <nowiki>{extensionAllowed} [An event derived from the data itself, possibly inserted in a post-hoc fashion.]</nowiki>
 ** Experiment 
-*** Control <nowiki>{extensionAllowed} [Information about states and events that control the experiment.]</nowiki>
+*** Control <nowiki>{extensionAllowed} [An event pertaining to setup and/or control of the experiment.]</nowiki>
 **** Condition <nowiki>[An event used to indicate an experimental condition. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the condition.]</nowiki>
 **** Instruction <nowiki>[Give an instruction to the participant .]</nowiki>
 **** Pause <nowiki>[An event indicating a stop in recording. Use Attribute/Temporal/Onset and Attribute/Temporal/Duration to specify the length of the pause.]</nowiki>    

--- a/HED-schema-reduced.mediawiki
+++ b/HED-schema-reduced.mediawiki
@@ -12,34 +12,19 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Sensory presentation <nowiki> [Something that can be perceived.]</nowiki>
 *** Experimental <nowiki>{extensionAllowed} [Primary category for time-locked stimulus events.]</nowiki>
 *** Environmental <nowiki>{extensionAllowed}[An environmental event, for example, a change in experimental context such as walking on dirt versus sidewalk or a loud noise in the next room.]</nowiki> 
-
 ** Participant action <nowiki>[Any action engaged in by the participant.]</nowiki>
-*** Response {extensionAllowed} <nowiki>[An action taken by a participant in response to an experimental or environmental stimulus.]</nowiki>
-*** Failure {extensionAllowed} <nowiki>{extensionAllowed} [Situation in which participant acts outside of the constraints of the experiment -- such as driving outside the boundary of a simulation experiment or using equipment incorrectly]</nowiki> 
-*** Incidental {extensionAllowed} <nowiki>[An action such as a yawn or stretch not in response to a sensory presentation.]</nowiki>
+*** Task-related {extensionAllowed} <nowiki>[An action taken by a participant in response to an experimental event.]</nowiki>
+*** Incidental {extensionAllowed} <nowiki>[A non-task-related action taken by the participant -- for example yawning, standing up during a seated experiment, or responding to a loud noise unrelated to the experiment.]</nowiki>
 ** Data feature <nowiki>{extensionAllowed} [An event derived from the data itself, possibly inserted in a post-hoc fashion.]</nowiki>
 ** Experiment 
-*** Control <nowiki>{extensionAllowed} [Information about states and events of the software program that controls the experiment]</nowiki> 
-**** Activity <nowiki>[Experiment-specific actions such as moving a piece in a chess game. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the task.]</nowiki> 
-**** Initial context <nowiki>[Set the starting context for the experiment.]</nowiki> 
-**** Sequence<nowiki>[Used to designate that this event is part of a sequence of control events]</nowiki> 
-***** Block <nowiki>[Each block has the same general context and contains several trials -- use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end.  Use Attribute/ID/Index/# to designate an identifier of the block.]</nowiki> 
-***** Experiment <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to indicate start and end of the experiment. Use Attribute/ID/Index/# to designate an identifier of the experiment.]</nowiki> 
-***** Pause <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the pause.]</nowiki> 
-***** Task <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the task.]</nowiki>  
-***** Trial <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the trial.]</nowiki> 
-**** Setup 
-**** Synchronization <nowiki>[An event used for synchronizing data streams]</nowiki> 
-***** Display refresh 
-***** Trigger 
-***** Status 
-***** Waiting for input 
-***** Loading 
-***** Error 
-*** Instruction <nowiki>[Give an instruction to the participant.]</nowiki> 
-*** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki> 
+*** Control <nowiki>{extensionAllowed} [Information about states and events that control the experiment.]</nowiki>
+**** Condition <nowiki>[An event used to indicate an experimental condition. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the condition.]</nowiki>
+**** Instruction <nowiki>[Give an instruction to the participant .]</nowiki>
+**** Pause <nowiki>[An event indicating a stop in recording. Use Attribute/Temporal/Onset and Attribute/Temporal/Duration to specify the length of the pause.]</nowiki>    
+**** Procedure <nowiki>[An event marking an experimental procedure, for example doing a saliva swab on the person, during the experiment. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the condition.]</nowiki>  
+**** Sync <nowiki>[An event used for synchronizing data streams.]</nowiki>
+*** Lab note <nowiki>{extensionAllowed} [Events that only have informational value and cannot be put in other event categories.]</nowiki> 
 *** Technical error <nowiki> {extensionAllowed} [Experimenters forgot to turn on something or the cord snagged and something may be wrong with the data.]</nowiki> 
-*** Informational <nowiki>{extensionAllowed} [Events that are only have informational value and cannot be put in other event categories.]</nowiki> 
 * Description <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=3}[Same as HED 1.0 description for human-readable text]</nowiki> 
 ** <nowiki># {takesValue}</nowiki> 
 * Label <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=0} [A label for the event that is less than 20 characters. For example /Label/Accept button. Please note that the information under this tag is primarily not for use in the analysis and is provided for the convenience in referring to events in the context of a single study. Please use Custom tag to define custom event hierarchies. Please do not mention the words Onset or Offset in the label. These should only be placed in Attribute/Temporal/Onset  and Attribute/Temporal/Offset.  Software automatically generates a final label with (onset) or (offset) in parentheses added to the original label. This makes it easier to automatically find onsets and offsets for the same event.]</nowiki> 

--- a/HED-schema-reduced.mediawiki
+++ b/HED-schema-reduced.mediawiki
@@ -1,4 +1,4 @@
-HED version: v1.4.0-restruct
+HED version: v1.5.0-restruct
 
 '''Syntax'''  
 

--- a/HED-schema-revision
+++ b/HED-schema-revision
@@ -1,0 +1,1168 @@
+HED version: v1.4.0-restruct
+
+'''Syntax'''  
+
+HED tags can only be separated by commas. Use semicolons (;) instead of commas in event descriptions since otherwise extra commas could confuse HED parsers.  
+From version 2.2, HED adheres to http://semver.org/ versioning. 
+
+!# start hed 
+
+'''Event''' 
+* Category <nowiki>{required, requireChild, position=1} [This is meant to designate the reason this event was recorded. Every event should have at least one category, but may have multiple categories.] </nowiki> 
+** Sensory presentation <nowiki> [Something that can be perceived.]</nowiki>
+*** Experimental <nowiki>{extensionAllowed} [Primary category for time-locked stimulus events.]</nowiki>
+*** Environmental <nowiki>{extensionAllowed}[An environmental event, for example, a change in experimental context such as walking on dirt versus sidewalk or a loud noise in the next room.]</nowiki> 
+
+** Participant action <nowiki>[Any action engaged in by the participant.]</nowiki>
+*** Response {extensionAllowed} <nowiki>[An action taken by a participant in response to an experimental or environmental stimulus.]</nowiki>
+*** Failure {extensionAllowed} <nowiki>{extensionAllowed} [Situation in which participant acts outside of the constraints of the experiment -- such as driving outside the boundary of a simulation experiment or using equipment incorrectly]</nowiki> 
+*** Incidental {extensionAllowed} <nowiki>[An action such as a yawn or stretch not in response to a sensory presentation.]</nowiki>
+** Data feature <nowiki>{extensionAllowed} [An event derived from the data itself, possibly inserted in a post-hoc fashion.]</nowiki>
+** Experiment 
+*** Control <nowiki>{extensionAllowed} [Information about states and events of the software program that controls the experiment]</nowiki> 
+**** Activity <nowiki>[Experiment-specific actions such as moving a piece in a chess game. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the task.]</nowiki> 
+**** Initial context <nowiki>[Set the starting context for the experiment.]</nowiki> 
+**** Sequence<nowiki>[Used to designate that this event is part of a sequence of control events]</nowiki> 
+***** Block <nowiki>[Each block has the same general context and contains several trials -- use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end.  Use Attribute/ID/Index/# to designate an identifier of the block.]</nowiki> 
+***** Experiment <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to indicate start and end of the experiment. Use Attribute/ID/Index/# to designate an identifier of the experiment.]</nowiki> 
+***** Pause <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the pause.]</nowiki> 
+***** Task <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the task.]</nowiki>  
+***** Trial <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the trial.]</nowiki> 
+**** Setup 
+**** Synchronization <nowiki>[An event used for synchronizing data streams]</nowiki> 
+***** Display refresh 
+***** Trigger 
+***** Status 
+***** Waiting for input 
+***** Loading 
+***** Error 
+*** Instruction <nowiki>[Give an instruction to the participant.]</nowiki> 
+*** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki> 
+*** Technical error <nowiki> {extensionAllowed} [Experimenters forgot to turn on something or the cord snagged and something may be wrong with the data.]</nowiki> 
+*** Informational <nowiki>{extensionAllowed} [Events that are only have informational value and cannot be put in other event categories.]</nowiki> 
+
+* Description <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=3}[Same as HED 1.0 description for human-readable text]</nowiki> 
+** <nowiki># {takesValue}</nowiki> 
+* Label <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=0} [A label for the event that is less than 20 characters. For example /Label/Accept button. Please note that the information under this tag is primarily not for use in the analysis and is provided for the convenience in referring to events in the context of a single study. Please use Custom tag to define custom event hierarchies. Please do not mention the words Onset or Offset in the label. These should only be placed in Attribute/Temporal/Onset  and Attribute/Temporal/Offset.  Software automatically generates a final label with (onset) or (offset) in parentheses added to the original label. This makes it easier to automatically find onsets and offsets for the same event.]</nowiki> 
+** <nowiki># {takesValue}</nowiki> 
+* Long name <nowiki>{requireChild, unique, predicateType=propertyOf, position=2} [A long name for the event that could be over 100 characters and could contain characters like vertical bars as separators. Long names are used for cases when one wants to encode a lot of information in a single string such as  Scenario | VehiclePassing | TravelLaneBLocked | Onset].</nowiki> 
+** <nowiki># {takesValue}</nowiki> 
+
+'''Item''' <nowiki>{extensionAllowed}</nowiki>
+* Object <nowiki> {extensionAllowed} [Visually discernable objects. This item excludes sounds that are Items but not objects]</nowiki>
+** Inanimate
+*** Bell
+*** Buzzer
+*** Cash register
+*** Clicker
+*** Fire alarm
+*** Siren
+** Vehicle 
+** Person 
+** Animal
+** Plant 
+** Building 
+** Food 
+** Clothing 
+* Geometric shape
+** 2D shape  <nowiki>[Geometric shapes]</nowiki> 
+** 3D shape
+** Pattern
+* Face 
+** Whole face with hair 
+** Whole face without hair 
+** Cut-out 
+** Parts only 
+*** Nose 
+*** Lips 
+*** Chin 
+*** Eyes 
+* Symbolic <nowiki> [Something that has a meaning, could be linguistic or not such as a stop signs.]</nowiki> 
+** Braille character 
+** Sign <nowiki>[Like the icon on a stop sign. This should not to be confused with the actual object itself.] </nowiki> 
+*** Traffic 
+**** Speed limit 
+***** <nowiki># {takesValue, isNumeric, unitClass=speed} [Always give units e.g. mph or kph]</nowiki> 
+** Character  
+*** Digit 
+*** Pseudo-character <nowiki> [Alphabet-like but not really]</nowiki> 
+*** Letter <nowiki> [Authograph or valid letters and numbers such as A or 5]</nowiki> 
+**** <nowiki># {takesValue}</nowiki> 
+** Composite <nowiki>[Has multiple of the above on it</nowiki> 
+* Multimedia
+** Photograph
+*** Natural scene 
+**** Aerial 
+**** Satellite 
+** Drawing <nowiki>[Cartoon or sketch]</nowiki> 
+*** Line drawing 
+** Film clip  
+** Sound clip
+** Commercial TV 
+** Animation 
+** Movie
+
+
+
+'''Sensory presentation''' <nowiki>{extensionAllowed} [Object manifestation]</nowiki> 
+
+* Auditory <nowiki>[Sound]</nowiki> 
+** ABR <nowiki>[Auditory Brainstem Response]</nowiki> 
+** Tone 
+** Siren 
+** Music 
+*** Chord sequence 
+*** Vocal 
+*** Instrumental
+*** Tone
+*** Genre
+** Noise 
+*** White 
+*** Colored <nowiki>[Not white --- for example a 1/f spectrum]</nowiki> 
+** Real world <nowiki> [For example people walking or machines operating]</nowiki> 
+*** Pedestrian 
+*** Footsteps 
+**** Walking 
+**** Running 
+*** Noisemaker 
+*** Construction noise 
+*** Machine 
+*** Vehicle 
+**** Horn 
+**** Aircraft 
+***** Airplane 
+***** Helicopter 
+**** Train 
+**** Cart 
+**** Car alarm 
+**** Car 
+**** Bicycle 
+** Nonverbal vocal 
+*** Emotional 
+**** Crying 
+**** Sighing 
+*** Gulp 
+*** Gurgle 
+*** Sneeze 
+*** Cough 
+*** Yawn 
+** Nonvocal <nowiki> [A car engine or gears grinding --- anything that is not made by a human or an animal]</nowiki> 
+*** Engine 
+'''Attribute''' <nowiki>{requireChild, extensionAllowed}</nowiki>
+* ID <nowiki>{requireChild}[Tag to identify any aspect of an event. Use parentheses to group an ID Value tag with an ID Type tag to qualify the kind of ID that the value represents.]</nowiki>
+** Collection <nowiki>[Identifier for an object in a specified collection]</nowiki>
+*** IAPS <nowiki>[International Affective Picture System]</nowiki> 
+**** # <nowiki>{takesValue}</nowiki>
+*** IADS <nowiki> [International Affective Digital Sounds]</nowiki> 
+**** # <nowiki>{takesValue}</nowiki>
+*** SAM <nowiki> [The Self-Assessment Manikin]</nowiki> 
+**** # <nowiki>{takesValue}</nowiki>
+** Group <nowiki>[ID that identifies a group of events associated with each other.]</nowiki>
+*** # <nowiki>{takesValue}</nowiki>
+** Index <nowiki>{requireChild}[Use this tag with a value for IDs that don't fall into another category.]</nowiki>
+*** # <nowiki>{takesValue}</nowiki>
+** Local <nowiki>[For IDs only defined in the scope of a single event. The local ID 5 in events 1 and 2 may refer to two different objects. The global IDs  directly under ID tag refer to the same object through the whole experiment]</nowiki>
+*** # <nowiki>{takesValue}</nowiki>
+** Participant <nowiki>[ID identifies a subject.]</nowiki>
+*** # <nowiki>{takesValue}</nowiki>
+** Permutation <nowiki>[ID is used to identify an ordering as for example to indicate block order in an experimental design.]</nowiki>
+*** # <nowiki>{takesValue}</nowiki>
+** Reference object <nowiki>[ID is used to a reference object to specify location with respect to.]</nowiki>
+*** # <nowiki>{takesValue}</nowiki>
+** State <nowiki>[ID is used to identify a group of events that are changing the state of a variable as for example when the onset means the offset of any other and a change in the state]</nowiki>
+*** # <nowiki>{takesValue}</nowiki>
+** Synchronization <nowiki>[ID is used to tag an event for synchronizing data streams.]</nowiki>
+*** # <nowiki>{takesValue}</nowiki>
+* Parameters <nowiki>{predicateType=propertyOf}</nowiki> 
+**<nowiki># {takesValue} [Experiment parameters in some a string. Do not used quotes.]</nowiki> 
+* Sensory presentation <nowiki>{requireChild}[Object manifestation]</nowiki>
+** Auditory
+** Olfactory
+** Tactile
+** Taste
+** Visual
+*** Rendering type <nowiki>{requireChild, predicateType=passThrough}</nowiki> 
+**** Screen 
+***** Head-mounted display
+***** View port <nowiki> [Two or more views on the same object --- for example one from top one from street view]</nowiki> 
+***** 2D 
+***** 3D 
+***** Movie 
+****** Video-tape 
+****** Motion-capture <nowiki>[Stick figure of motion capture of someone else]</nowiki> 
+******* Point light 
+******* Stick figure 
+******* Outline 
+****** Flickering 
+****** Steady state 
+**** Real-world 
+**** LED <nowiki>[Stimulus is turning on/off one or a few LEDs]</nowiki> 
+
+* Spatial <nowiki>{requireChild}</nowiki>
+** Direction <nowiki>{requireChild} [Coordinate system is inferred from Attribute/Location. To specify a vector combine subnodes with number --- for example Attribute/Top/10, Attribute/Direction/Left/5 to create a vector with coordinates 10 and 5]</nowiki> 
+*** Bottom 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki>
+*** Left 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+*** Right  
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki>  
+*** Top <nowiki> [Combine Attribute/Direction/Top and Attribute/Direction/Left to mean the upper left]</nowiki> 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+*** Angle <nowiki>[Clockwise angle in degrees from vertical]</nowiki> 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise angle in degrees from vertical]</nowiki> 
+*** North 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+*** South 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+*** East 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+*** West 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+*** Forward <nowiki> [Like a car moving forward]</nowiki> 
+*** Backward <nowiki>[Like a car moving backward]</nowiki> 
+
+** Location {requireChild} <nowiki>[Spot or center of an area. Use Area were you are referring to something with significant extent and emphasizing its boundaries, like a city]</nowiki> 
+*** <nowiki># {takesValue} [location label]</nowiki> 
+*** Lane <nowiki>[For example a car lane]</nowiki> 
+**** Cruising  
+**** Leftmost 
+**** Left of expected 
+**** Oncoming 
+**** Passing <nowiki>[The lane that cars use to take over other cars]</nowiki> 
+**** Rightmost 
+**** Right of expected 
+*** Real-world coordinates <nowiki>{requireChild}</nowiki> 
+**** Room 
+***** xyz <nowiki> {requireChild} [have a subnode, e.g. Attribute/Location/Real-world coordinates/Room/xyz/[10 50 30]]</nowiki> 
+****** <nowiki># {takesValue}</nowiki> 
+*** Reference frame <nowiki>{requireChild}</nowiki> 
+**** Relative to participant
+***** Azimuth <nowiki>{requireChild}</nowiki> 
+****** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise with units preferably in degrees]</nowiki>  
+***** Back 
+***** Distance <nowiki>{requireChild}</nowiki> 
+****** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} [Distance is in meters by default]</nowiki> 
+****** Far
+****** Moderate  
+****** Near 
+***** Elevation <nowiki>{requireChild}</nowiki> 
+****** <nowiki># {takesValue, isNumeric, unitClass=angle} [Preferably in degrees]</nowiki> 
+***** Front 
+***** Left 
+***** Right 
+**** Specified absolute reference 
+*** Screen <nowiki>[Specify displacements from each subnode in pixels or degrees or meters. Specify units such as Attribute/Spatial/Location/Screen/Top/12 px]</nowiki> 
+**** Angle  
+***** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise angle in degrees from vertical]</nowiki> 
+**** Bottom 
+***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+**** Center 
+***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki>
+**** Center displacement 
+***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength} [Displacement from screen center, in any direction, in degrees, cm, or other lengths]</nowiki> 
+***** Horizontal 
+****** <nowiki># {takesValue, isNumeric, unitClass=angle,  unitClass=physicalLength} [Displacement from screen center in any direction]</nowiki> 
+***** Vertical 
+****** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength}[Displacement from screen center in any direction]</nowiki>  
+**** Left 
+***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+**** Right  
+**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+**** Top <nowiki>[You can combine Attribute/Location/Top and Attribute/Location/Left to designate UpperLeft and so on]</nowiki> 
+***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
+** Object orientation <nowiki>{requireChild}</nowiki> 
+*** Rotated 
+**** Degrees <nowiki>{requireChild}</nowiki> 
+***** <nowiki>#{takesValue, isNumeric, unitClass=angle}[Preferably in degrees]</nowiki> 
+** Object side <nowiki>{requireChild} [Could be the left,  right, or both sides of a person or a vehicle]</nowiki> 
+*** Back 
+*** Bottom 
+*** Bow <nowiki>[Front of a ship]</nowiki> 
+*** Driver side <nowiki>[Side of a car]</nowiki> 
+*** Front 
+*** Left 
+*** Passenger side <nowiki>[Side of a car]</nowiki> 
+*** Port 
+*** Right 
+*** Stern <nowiki>[Back of the ship]</nowiki>
+*** Starboard 
+*** Top 
+** Size <nowiki>{requireChild}</nowiki>
+*** Angle<nowiki>{requireChild}</nowiki> 
+**** <nowiki># {takesValue, isNumeric, unitClass=angle} [In degrees or other units of angle]</nowiki> 
+*** Area <nowiki>{requireChild}</nowiki> 
+**** <nowiki># {takesValue, isNumeric, unitClass=area}</nowiki>
+*** Height
+**** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} [Default units are meters]</nowiki>
+*** Length<nowiki>{requireChild}</nowiki> 
+**** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} [In meters or other units of length ]</nowiki> 
+*** Volume <nowiki>{requireChild}</nowiki> 
+**** <nowiki># {takesValue, isNumeric, unitClass=volume} [In cubic-meters or other units of volume]</nowiki> 
+*** Width
+**** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} </nowiki><nowiki>[in meters]</nowiki> 
+* Temporal <nowiki>{requireChild}</nowiki>
+** Duration <nowiki>{requireChild} [An offset that is implicit after duration time passed from the onset]</nowiki>
+*** <nowiki># {takesValue, isNumeric, unitClass=time}</nowiki>
+** Onset <nowiki>[Default]</nowiki> 
+** Offset
+** Repetition <nowiki>{requireChild} [When the same type of event such as a fixation on the exact same object happens multiple times and it might be necessary to distinguish the first look vs. others]</nowiki> 
+*** <nowiki># {takesValue, isNumeric} [Number starting from 1 where 1 indicates the first occurrence and 2 indicates the second occurrence]</nowiki> 
+** Response start delay <nowiki>[The time interval between this (stimulus) event and the start of the response event specified, usually by grouping with the event ID of the response start event.]</nowiki>
+*** <nowiki># {takesValue, unitClass=time}</nowiki>
+** Response end delay <nowiki>[The time interval between this (stimulus) event and the end of the response event specified, usually by grouping with the event ID of the response end event.]</nowiki>
+*** <nowiki># {takesValue, unitClass=time}</nowiki>
+** Rate <nowiki>[Number of occurrences in a unit of time.]</nowiki> 
+*** <nowiki># {takesValue, isNumeric, unitClass=frequency} [In Hz]</nowiki> 
+** Uncertainty <nowiki> {requireChild} [Use to specify the amount of uncertainty in the timing of the event. Please notice that this is different from Attribute/Probability tag which relates to the occurrence of event and can be interpretative as the integral of probability density across a distribution whose shape (temporal extent) is specified by Attribute/Temporal uncertainty]. </nowiki> 
+*** <nowiki># {takesValue, isNumeric, unitClass=time} [implies that the temporal uncertainty is a uniform distribution with the amount of time provided, extending on both side. E.g. "0.5 s" specifies a 1-second range centered at event latency.</nowiki> 
+*** Standard deviation <nowiki>{requireChild} [implies that the distribution of temporal uncertainty is Gaussian with the provided standard deviation (in seconds).]</nowiki> 
+**** <nowiki># {takesValue, isNumeric, unitClass=time}</nowiki>
+* Imagined <nowiki>[This is used to identity that the (sub)event only happened in participant's imagination, e.g.  imagined movements in motor imagery paradigms.]</nowiki>
+* Condition <nowiki>{requireChild} [Specifies the value of an independent variable (number of letters, N, in an N-back task) or function of independent variables that is varied or controlled for in the experiment.  This attribute is often specified at the task level and can be associated with specification of an experimental stimulus or an experiment context (e.g. 1-back, 2-back conditions in an N-back task, or changing the target type from faces to houses in a Rapid Serial Visual Presentation, or RSVP, task.)]</nowiki>
+** # <nowiki>{takesValue} [the condition]</nowiki> 
+* Action judgment <nowiki>[External judgment (assumed to be ground truth, e.g. from an experiment control software or an annotator) about participant actions such as answering a question, failing to answer in time, etc.]</nowiki> 
+** Correct 
+** Incorrect <nowiki>[Wrong choice but not time out]</nowiki> 
+** Indeterminate <nowiki>[It cannot be determined that the action was correct or incorrect.]</nowiki> 
+** Time out 
+*** Missed <nowiki>[Participant failed or could not have perceived the instruction due to their eyes being off-screen or a similar reason. Not easy to deduce this but it is possible]</nowiki> 
+** Inappropriate <nowiki>[A choice that is not allowed such as moving a chess piece to a location it should not go based on game rules]</nowiki>
+
+* Social <nowiki>[Involving interactions among multiple agents such as humans or dogs or robots]</nowiki> 
+* Peak <nowiki>[Peak velocity or  acceleration or jerk]</nowiki>
+* Item count <nowiki>{requireChild} [Number of items for example when there are 3 cars and they are identified as a single item]</nowiki> 
+** <nowiki># {takesValue, isNumeric} [Numeric value of number of items #]</nowiki> 
+** <nowiki><=# {takesValue, isNumeric} [Number of items less than or equal to #]</nowiki> 
+** <nowiki>>=# {takesValue, isNumeric} [Number of items  more than or equal to #]</nowiki> 
+* Auditory <nowiki></nowiki> 
+** Frequency <nowiki>{requireChild}</nowiki> 
+*** <nowiki># {takesValue, isNumeric, unitClass=frequency} [In HZ]</nowiki> 
+** Loudness <nowiki>{requireChild}</nowiki> 
+*** <nowiki># {takesValue, isNumeric, unitClass=intensity} [in dB]</nowiki> 
+** Ramp up <nowiki>[Increasing in amplitude]</nowiki> 
+** Ramp down <nowiki>[Decreasing in amplitude]</nowiki> 
+* Blink
+** Time shut <nowiki>{requireChild} [The amount of time the eyelid remains closed (typically measured as 90% of the blink amplitude), in seconds.]</nowiki> 
+*** <nowiki># {takesValue, isNumeric, unitClass=time, default=s}</nowiki> 
+** Duration <nowiki>{requireChild} [Duration of blink, usually the half-height blink duration in seconds taken either from base or zero of EEG signal. For eye-trackers, usually denotes interval when pupil covered by eyelid.]</nowiki>
+***<nowiki># {takesValue, isNumeric, unitClass=time, default=s}</nowiki> 
+** PAVR <nowiki>{requireChild} [Amplitude-Velocity ratio, in centiseconds]</nowiki> 
+*** <nowiki># {takesValue, isNumeric, unitClass=time, default=centiseconds}</nowiki> 
+** NAVR <nowiki>{requireChild} [Negative Amplitude-Velocity ratio, in centiseconds]</nowiki> 
+*** <nowiki># {takesValue, isNumeric, unitClass=time, default=centiseconds}</nowiki> 
+* Visual <nowiki></nowiki>
+** Bistable 
+** Background 
+** Foreground 
+** Up-down separated <nowiki>[Stimuli presented both at the top and the bottom of fovea]</nowiki> 
+*** <nowiki># {takesValue, isNumeric, unitClass=angle} [Angle of separation in degrees by default]</nowiki> 
+** Bilateral <nowiki>[For bilateral visual field stimulus presentations]</nowiki> 
+*** <nowiki># {takesValue, isNumeric, unitClass=angle} [Angle of separation in degrees by default] </nowiki> 
+** Motion 
+*** Down    
+**** <nowiki># {takesValue, isNumeric, unitClass=speed} [e.g. 3 degrees-per-second]</nowiki> 
+*** Up 
+**** <nowiki># {takesValue, isNumeric, unitClass=speed} [e.g. 3 degrees-per-second]</nowiki> 
+*** Horizontal 
+**** Right   
+***** <nowiki># {takesValue, isNumeric, unitClass=speed} [e.g. 3 degrees-per-second]</nowiki> 
+**** Left 
+***** <nowiki># {takesValue, isNumeric, unitClass=speed} [e.g. 3 degrees-per-second]</nowiki> 
+*** Oblique 
+**** Clock face 
+***** <nowiki>#  {takesValue, unitClass=time} [For example  4:30]</nowiki> 
+** Fixation point 
+** Luminance <nowiki>{requireChild}</nowiki> 
+*** <nowiki># {takesValue, isNumeric, unitClass=luminousIntensity}[In candelas by default]</nowiki> 
+** Color <nowiki>{requireChild}</nowiki> 
+*** Dark 
+*** Light 
+*** Aqua <nowiki>[These are CSS 3 basic color names]</nowiki> 
+*** Black 
+*** Fuchsia  
+*** Gray 
+*** Lime  
+*** Maroon 
+*** Navy 
+*** Olive  
+*** Purple  
+*** Silver  
+*** Teal  
+*** White  
+*** Yellow 
+*** Red 
+**** <nowiki># {takesValue, isNumeric} [R value of RGB between 0 and 1]</nowiki> 
+*** Blue 
+**** <nowiki># {takesValue, isNumeric} [B value of RGB between 0 and 1]</nowiki> 
+*** Green 
+**** <nowiki># {takesValue, isNumeric} [G value of RGB between 0 and 1]</nowiki> 
+*** Hue <nowiki>{requireChild}</nowiki> 
+**** <nowiki># {takesValue, isNumeric} [H value of HSV between 0 and 1]</nowiki> 
+*** Saturation <nowiki>{requireChild}</nowiki> 
+**** <nowiki># {takesValue, isNumeric} [S value of HSV between 0 and 1]</nowiki> 
+*** Value <nowiki>{requireChild}</nowiki> 
+**** <nowiki># {takesValue, isNumeric} [V value of HSV between 0 and 1]</nowiki> 
+*** Achromatic <nowiki>[Indicates gray scale]</nowiki> 
+**** <nowiki># {takesValue, isNumeric} [White intensity between 0 and 1]</nowiki> 
+* Nonlinguistic <nowiki>[Something that conveys meaning without using words such as the iconic pictures of a man or a woman on the doors of restrooms. Another example is a deer crossing sign with just a picture of jumping deer.]</nowiki> 
+* Semantic <nowiki>[Like in priming or in congruence]</nowiki> 
+* Language 
+** Unit <nowiki>{predicateType=passThrough}</nowiki> 
+*** Phoneme 
+*** Syllable 
+*** Word 
+**** Noun 
+***** Proper <nowiki>[A proper noun that  refers to a unique entity  such as London or Jupiter]</nowiki> 
+***** Common <nowiki>[A noun that refers to a class of entities such as cities or planets or corporations  such as a Dog or a Skyscraper]</nowiki> 
+**** Verb 
+**** Adjective 
+**** Pseudoword 
+**** <nowiki># {takesValue} [Actual word]</nowiki> 
+*** Sentence 
+**** Full 
+**** Partial 
+**** <nowiki># {takesValue} [Actual sentence]</nowiki> 
+*** Paragraph 
+**** <nowiki># {takesValue} [Actual paragraph]</nowiki> 
+*** Story <nowiki>[Multiple paragraphs making a detailed account]</nowiki> 
+** Family <nowiki>{predicateType=passThrough}</nowiki> 
+*** Asian
+**** Chinese 
+**** Japanese 
+*** Latin
+**** English 
+**** German 
+**** French 
+* Induced <nowiki>[Such as inducing emotions or keeping someone awake or in a coma with an external intervention]</nowiki> 
+* Emotional 
+** Arousal <nowiki>[Only in the context of 2D emotion representation]</nowiki> 
+*** <nowiki># {takesValue, isNumeric} [A value between -1 and 1]</nowiki> 
+** Positive valence <nowiki> [Valence by itself can be the name of an emotion such as sadness so this tag distinguishes the type of emotion]</nowiki> 
+*** <nowiki># {takesValue, isNumeric} [Ranges from 0 to 1]</nowiki> 
+** Negative valence 
+*** <nowiki># {takesValue, isNumeric}[Ranges from 0 to 1]</nowiki> 
+* Priming 
+** Motoric 
+** Emotional 
+** Perceptual 
+* Subliminal 
+** Unmasked 
+** Masked 
+*** Forward 
+*** Backward 
+* Supraliminal <nowiki>[By default this is assumed about each stimulus]</nowiki> 
+* Liminal <nowiki>[At the 75%-25% perception threshold]</nowiki> 
+* Probability <nowiki> [Use to specify the level of certainty about the occurrence of the event. Use either numerical values as the child node or 'low', 'high', etc.]</nowiki> 
+
+* Presentation <nowiki>{requireChild}[Attributes associated with visual, auditory, tactile, etc. presentation of an stimulus]</nowiki>
+** Fraction <nowiki>{requireChild} [the fraction of presentation of an Oddball or Expected stimuli to the total number of same-class presentations, e.g. 10% of images in an RSVP being targets] </nowiki> 
+*** <nowiki># {takesValue, isNumeric}</nowiki>
+** Cued <nowiki>[what is presented is cued to the presentation of something else] </nowiki> 
+** Background <nowiki>[presented in the background such as background music, background image, etc. The main factor here is that background presentations are to be ignored, e.g. ignore math question auditory stimuli.] </nowiki> 
+* Intended effect <nowiki>[This tag is to be grouped with Participant/Effect/Cognitive to specify the intended cognitive effect (of the experimenter). This is to differentiate the resulting group with Participant/Effect which specifies the actual effect on the participant. For example, in an RSVP experiment if an image is intended to be perceived as a target, (Participant/Effect/Cognitive/Target, Attribute/Intended effect) group is added. If the image was perceived by the subject as a target (e.g. they pressed a button to indicate so), then the tag Participant/Effect/Cognitive/Target is also added: Participant/Effect/Cognitive/Target, (Participant/Effect/Cognitive/Target, Attribute/Intended effect). otherwise the Participant/Effect/Cognitive/Target tag is not included outside of the group.]</nowiki>
+* Instruction <nowiki> [This tag is placed in events of type Event/Category/Experimental stimulus/Instruction, grouped with one or more Action/ tags to replace the detailed specification XXX in Event/Category/Experimental stimulus/Instruction/XXX) in previous versions. Usage example:  Event/Category/Experimental stimulus/Instruction, (Action/Fixate, Attribute/Instruction) ]</nowiki>
+* Participant indication <nowiki> [This tag is placed in events of type Event/Category/Participant response and grouped with Participant/Effect/Cognitive/.. tags to specify the type of cognitive effect the participant has experienced. For example, in an RSVP paradigm, the subject can indicate the detection of a target with a button press. The HED string associated with this button press must include (Attribute/Participant indication, Participant/Effect/Cognitive/Target,...)]</nowiki>
+* Path <nowiki>{requireChild}</nowiki> 
+** Velocity  <nowiki>[Use Attribute/Temporal/Onset or Attribute/Temporal/Offset to specify onset or offset]</nowiki> 
+*** <nowiki># {takesValue, isNumeric, unitClass=speed} [Numeric value with default units of m-per-s]</nowiki> 
+** Acceleration 
+*** <nowiki># {takesValue, isNumeric, unitClass=acceleration} [Numeric value with default units of m-per-s2] </nowiki> 
+** Jerk 
+*** <nowiki># {takesValue, isNumeric, unitClass=jerk} [Numeric value with default units of m-per-s3] </nowiki> 
+** Constrained <nowiki>[For example a path cannot cross some region]</nowiki> 
+* File <nowiki>{requireChild} [File attributes]</nowiki> 
+** Name 
+** Size 
+** Number
+*** <nowiki># {takesValue, isNumeric, unitClass=memorySize} [Numeric value with default units of mb]</nowiki> 
+** <nowiki># {takesValue, isNumeric}[Number of files]</nowiki> 
+* Object control <nowiki>{requireChild} [Specifies control such as for a vehicle]</nowiki> 
+** Perturb 
+** Collide 
+** Near miss <nowiki>[Almost having an accident resulting in negative consequences]</nowiki> 
+** Correct position <nowiki>[After a lane deviation or side of the walkway]</nowiki> 
+** Halt <nowiki>[Time at which speed becomes exactly zero]</nowiki> 
+** Brake 
+** Shift lane 
+** Cross <nowiki>[Crossing in front of another object such as a vehicle]</nowiki> 
+** Pass by <nowiki>[Passing by another object or the participant]</nowiki> 
+** Accelerate
+** Decelerate
+* Association <nowiki>{requireChild}</nowiki> 
+** Another person <nowiki>[Item such as a cup belonging to another person]</nowiki> 
+** Same person <nowiki>[Item such as a cup belonging to the participant]</nowiki> 
+* Extraneous <nowiki>[Button presses that are not meaningful for example due to intrinsic mechanical causes after a meaningful press]</nowiki>
+* Role <nowiki> {requireChild} [The role of the agent (participant, character, AI..)]</nowiki> 
+** Leader 
+** Follower 
+** <nowiki># {takesValue}</nowiki> 
+
+'''Action'''<nowiki>{extensionAllowed}[May or may not be associated with a prior stimulus.]</nowiki> 
+* Involuntary <nowiki>[Like sneezing or tripping on something or hiccuping]</nowiki> 
+** Hiccup 
+** Cough 
+** Sneeze 
+** Stumble <nowiki>[Temporary and involuntary loss of balance]</nowiki> 
+** Fall 
+** Tether Jerk <nowiki>[When a tether attached to the subject is stuck/snagged and forces the participant to involuntary accommodate/react to it]</nowiki> 
+** Clear Throat 
+** Yawn 
+** Sniffle 
+** Burp 
+** Drop <nowiki>[For example something  drops from subject’s hand]</nowiki>
+* Make fist
+** Open and close <nowiki>[Continue to open and close the fist, for example in motor imagery paradigms.]</nowiki>
+* Curl toes
+** Open and close <nowiki>[Continue to curl and uncurl toes, for example in motor imagery paradigms.]</nowiki>
+* Button press <nowiki>{extensionAllowed}</nowiki> 
+** Touch screen 
+** Keyboard 
+** Mouse 
+** Joystick 
+* Button hold <nowiki>[Press a button and keep it pressed]</nowiki> 
+* Button release 
+* Cross boundary 
+** Arrive 
+** Depart 
+* Speech 
+* Hum 
+* Eye saccade <nowiki> [Use Attribute/Peak for the middle of saccade and Attribute/Temporal/Onset for the start of a saccade]</nowiki> 
+* Eye fixation 
+* Eye blink
+** Left base <nowiki>[The time of the first detectable eyelid movement on closing.]</nowiki>
+** Left zero <nowiki>[The last time at which the EEG/EOG signal crosses zero during eyelid closing.]</nowiki>
+** Left half height <nowiki>[The time at which the EEG/EOG signal reaches half maximum height during eyelid closing.]</nowiki>
+** Max <nowiki>[The time at which the eyelid is the most closed.]</nowiki> 
+** Right half height <nowiki>[The time at which the EEG/EOG signal reaches half maximum height during eyelid opening.]</nowiki>
+** Right zero <nowiki>[The first time at which the EEG/EOG signal crosses zero during eyelid opening.]</nowiki>
+** Right base <nowiki>[The time of the last detectable eyelid movement on opening.]</nowiki>
+* Eye close <nowiki>[Close eyes and keep closed for more than approximately 0.1 s]</nowiki> 
+** Keep <nowiki>[Keep the eye closed. If a value is provided it indicates the duration for this.]</nowiki> 
+*** # <nowiki>[the duration (by default in seconds) that they keep their eye closed.]{takesValue, isNumeric, unitClass=time}</nowiki>
+* Eye open <nowiki>[Open eyes and keep open for more than approximately 0.1 s]</nowiki>
+** Keep <nowiki>[Keep the eye open. If a value is provided it indicates the duration for this.]</nowiki> 
+*** # <nowiki>[the duration (by default in seconds) that they keep their eye open.]{takesValue, isNumeric, unitClass=time}</nowiki>
+*** With blinking <nowiki>[Default. Allow blinking during the eye-open period.]</nowiki>
+*** Without blinking <nowiki>[Without blinking during the eye-open period.]</nowiki>
+* Turn <nowiki>[Change in direction of movement or orientation. This includes both turn during movement on a path and also rotations such as head turns]</nowiki> 
+* Point 
+* Push 
+* Grab 
+* Tap <nowiki>[When there is nothing to be pressed for example like tapping a finger on a chair surface to follow a rhythm]</nowiki> 
+* Lift 
+* Reach <nowiki>[Requires a goal such as reaching to touch a button or to grab something. Stretching your body does not count as reach.]</nowiki> 
+** To Grab 
+** To Touch 
+* Course correction <nowiki>[Change the direction of a reach in the middle to adjust for a moving target.]</nowiki> 
+* Interact
+** With human
+* Take survey
+* Stretch <nowiki>[Stretch your body such as when you wake up]</nowiki> 
+* Bend 
+* Deep breath 
+* Laugh 
+* Sigh 
+* Groan 
+* Scratch 
+* Switch attention  
+** Intramodal <nowiki>[In the same modality but with a change in details  such as changing from paying attention to red dots and instead of blue dots]</nowiki> 
+** Intermodal <nowiki>[Between modalities such as changing from audio to visual]</nowiki> 
+*** From modality 
+*** To modality 
+
+* Walk 
+** Stride <nowiki>[Use onset and offset attributes to indicate different walking stride stages]</nowiki> 
+** Faster <nowiki>[increasing the speed of walking]</nowiki> 
+** Slower <nowiki>[decreasing the speed of walking]</nowiki> 
+* Control vehicle <nowiki>[Controlling an object that you are aboard]</nowiki> 
+** Drive <nowiki>[Driving a vehicle such as a car]</nowiki> 
+*** Correct <nowiki>[Correct for a perturbation]</nowiki> 
+*** Near miss 
+*** Collide 
+** Stop <nowiki>[Brake a car]</nowiki> 
+** Pilot <nowiki>[Pilot a vehicle such as an airplane]</nowiki> 
+* Teleoperate <nowiki>[Control an object that you are not aboard]</nowiki> 
+* Allow <nowiki>[Allow access to something such as allowing a car to pass]</nowiki> 
+* Deny <nowiki> [Deny access to something such as preventing someone to pass]</nowiki> 
+* Step around 
+* Step over 
+* Step on 
+* Swallow 
+* Flex 
+* Evade 
+* Shrug 
+* Dance 
+* Open mouth 
+* Whistle 
+* Read 
+* Attend
+* Recall
+* Generate
+* Repeat
+* Hold breath 
+* Breathe
+* Rest 
+* Count 
+* Move 
+** Upper torso 
+** Lower torso 
+** Whole body 
+* Speak
+* Sing
+* Detect
+* Name 
+* Smile 
+* Discriminate 
+* Track
+* Encode 
+* Eye-blink inhibit
+
+'''Participant''' <nowiki>{extensionAllowed}</nowiki> 
+* Effect <nowiki> [How the stimulus effects the participants]</nowiki> 
+** Cognitive 
+*** Meaningful 
+*** Not meaningful 
+*** Newly learned meaning 
+*** Reward 
+**** Low 
+**** Medium 
+**** High 
+**** <nowiki># {takesValue, isNumeric, unitClass=currency} [Monetary values in some currency such as $10, or the ratio of the reward to the maximum possible (3 of max 10 becomes 0.3), or number Points]</nowiki> 
+*** Penalty 
+**** Low 
+**** Medium 
+**** High 
+**** <nowiki># {takesValue, isNumeric, unitClass=currency} [Absolute monetary values in some currency, for example $1, or the ratio of the reward to the maximum possible (3 of max 10 becomes 0.3), or number of Points]</nowiki> 
+*** Error 
+**** Self originated 
+**** Other originated 
+***** Human 
+***** Non-human 
+**** Expected 
+**** Unexpected 
+**** Planned <nowiki>[The error feedback was given regardless of the validity of subject response as in a yoked design] </nowiki> 
+*** Threat 
+**** To self 
+**** To others 
+***** Close 
+*** Warning <nowiki>[As in a warning message that you are getting too close to the shoulder in a driving task]</nowiki> 
+*** Oddball <nowiki> [Unexpected or infrequent]</nowiki> 
+**** One stimulus <nowiki>[Only oddballs are present but no frequent stimuli exist. See http://dx.doi.org/10.1016/0167-8760(96)00030-X]</nowiki> 
+**** Two stimuli <nowiki>[There are non-targets and targets. See http://dx.doi.org/10.1016/0167-8760(96)00030-X]</nowiki> 
+**** Three stimuli <nowiki>[There are regular non-targets and targets and infrequent non-targets, see http://dx.doi.org/10.1016/0167-8760(96)00030-X]</nowiki> 
+**** Silent counting 
+**** Button pressing for target 
+**** Button pressing for all 
+*** Target <nowiki>[Something the subject is looking for]</nowiki> 
+*** Non-target <nowiki>[Make sure to tag Expected if the Non-target is frequent] </nowiki> 
+*** Novel <nowiki>[Genuinely novel such as an event occurring once or so per experiment]</nowiki> 
+*** Expected <nowiki>[Of low information value, for example frequent Non-targets in an RSVP paradigm]</nowiki> 
+**** Standard 
+**** Distractor 
+*** Valid <nowiki>[Something that is understood to be valid such as an ID matches the person being displayed and it has all the  correct information]</nowiki> 
+*** Invalid <nowiki>[Something that is understood to not be valid such as like an ID with an impossible date-of-birth, or a photo not matching the person presenting it]</nowiki> 
+*** Congruence 
+**** Congruent <nowiki>[Like in Stroop paradigm when blue colored text displays the word blue] </nowiki> 
+**** Incongruent <nowiki> [Like in Stroop paradigm whena blue colored text reading displays the word red] </nowiki> 
+**** Temporal synchrony 
+***** Synchronous <nowiki>[When a mouse click sound happens right after clicking it]</nowiki> 
+***** Asynchronous <nowiki> [When a mouse click sound happens with significant delay which give could the person a strange feeling. Or if in a movie the sound of the explosion is heard before it appears visually.] </nowiki> 
+*** Feedback 
+**** Correct <nowiki>[Confirm something went well and last action was correct]</nowiki> 
+**** Incorrect  <nowiki>[Confirm something went wrong and last action was incorrect]</nowiki> 
+**** Non-informative <nowiki>[Feedback that provides no information in regards to correct, incorrect, etc.]</nowiki> 
+**** Expected <nowiki> [Feedback was expected as in a positive feedback after a response that was expected to be correct.]</nowiki> 
+**** Unexpected <nowiki>[Feedback was unexpected as when positive feedback was received when response was expected to be incorrect.]</nowiki> 
+**** On accuracy <nowiki>[Feedback was provided by evaluating response accuracy]</nowiki> 
+**** On reaction time <nowiki>[Feedback was provided by evaluating subject reaction time]</nowiki> 
+**** To self <nowiki>[Default]</nowiki> 
+**** To other <nowiki>[Observed feedback to another person such as in a social paradigm]</nowiki> 
+**** Deterministic <nowiki>[Feedback has a fixed relationship to what happened before]</nowiki> 
+**** Stochastic <nowiki>[Feedback is non-deterministic and does not have fixed relationship with what has happened before in the experiment]</nowiki> 
+**** False feedback <nowiki>[Feedback that was not honest for example as in feedback of correct on an incorrect response or vice versa]</nowiki> 
+***** Negative <nowiki> [Negative feedback was provided when it was not deserved]</nowiki> 
+***** Positive <nowiki>[Positive feedback was provided when it was not deserved]</nowiki> 
+*** Cue <nowiki>[An indicator of a future event, e.g. a sound cue that in 2-5 seconds a perturbation in driving will occur. Use (... Participant/Effect/Cognitive/Cue ~ [hed tags for the event to follow, or main aspect of the event to follow]) syntax.]</nowiki> 
+**** Constant delay <nowiki>[The cue is for an event that will happen after a constant delay.]</nowiki>
+***** # {takesValue, isNumeric, unitClass=time} <nowiki>[The delay, e.g. in seconds.]</nowiki>
+**** Variable delay <nowiki>[The cue is for an event that will happen after a variable delay.]</nowiki>
+***** # {takesValue} <nowiki>[The interval, e.g. between 2-5 seconds, of the variable delay.]</nowiki>
+** Visual 
+*** Foveal 
+*** Peripheral     
+*** Perturbation <nowiki>[Sudden movement or perturbation of the virtual environment in a car driving or other scenario]</nowiki> 
+** Auditory 
+*** Stereo 
+*** Mono 
+**** Left 
+**** Right 
+** TMS 
+*** With SPGS <nowiki>[SPGS stands for spatial position guiding system]</nowiki> 
+*** Without SPGS <nowiki>[SPGS stands for spatial position guiding system]</nowiki> 
+** Tactile 
+*** Vibration 
+*** Acupuncture 
+*** Eye puff 
+*** Swab <nowiki>[Mouth swab]</nowiki> 
+** Vestibular 
+*** Shaking [being shaken or jerked around] 
+** Pain 
+*** Heat 
+*** Cold 
+*** Pressure 
+*** Electric shock 
+*** Laser-evoked 
+** Taste 
+** Smell 
+** Body part 
+*** Whole Body 
+*** Eye 
+*** Arm 
+**** Hand 
+***** Finger 
+****** Index 
+****** Thumb 
+****** Ring 
+****** Middle 
+****** Small <nowiki>[Pinkie or little finger]</nowiki> 
+*** Leg 
+**** Feet 
+***** Toes 
+*** Head 
+**** Face 
+***** Eyebrow 
+***** Lip 
+***** Forehead 
+***** Mouth 
+***** Nose 
+***** Chin 
+***** Cheek 
+*** Torso 
+* State <nowiki>{requireChild}</nowiki> 
+** Level of consciousness <nowiki>{requireChild}</nowiki> 
+*** Awake 
+*** Drowsy 
+*** Sleep
+**** Stage <nowiki>{requireChild}</nowiki>
+***** <nowiki># {takesValue} [a number between 1 to 4, or 'REM']</nowiki>   
+*** Drunk 
+*** Anesthesia 
+*** Locked-in 
+*** Coma 
+*** Vegetative 
+*** Brain-dead 
+** Emotion <nowiki>{requireChild}</nowiki> 
+*** Awe 
+*** Frustration 
+*** Joy 
+*** Anger 
+*** Happiness 
+*** Sadness 
+*** Love 
+*** Fear 
+*** Compassion 
+*** Jealousy 
+*** Contentment 
+*** Grief 
+*** Relief 
+*** Excitement 
+*** Disgust 
+*** Neutral <nowiki>[None of the above]</nowiki> 
+** Sense of community <nowiki>[Primed to have an emotion such as patriotism]</nowiki> 
+*** <nowiki># {takesValue, isNumeric} [SCI stands for Sense of Community Index]</nowiki> 
+** Sense of social justice 
+*** Distributive 
+*** Poverty  
+*** Inequality 
+*** Procedural 
+*** Interpersonal 
+*** Informational 
+** Stress level <nowiki>{requireChild}</nowiki> 
+*** <nowiki>#  {takesValue, isNumeric} [A number between 0 and 1]</nowiki> 
+** Task load <nowiki>{requireChild}</nowiki> 
+*** <nowiki># {takesValue, isNumeric} [A number between 0 and 1]</nowiki> 
+** Under time pressure 
+*** Response window 
+**** <nowiki># {takesValue, isNumeric, unitClass=time} [Default time is seconds]</nowiki> 
+*** Competitive <nowiki> [Subject is competing against an opponent as for example when the faster respondent wins]</nowiki> 
+** Social interaction <nowiki>[Social]</nowiki> 
+*** Pseudo <nowiki>[Instructed so but actually not as when the other person may not exist in real world such as the case of a computer program agent]</nowiki> 
+** Passive <nowiki>[There is a stimulus presentation but no behavioral measurements are collected from the subject. Subject is instructed not to make any behavioral outputs for example when told to carefully watch/listen/sense. The resting state is not considered passive.]</nowiki> 
+** Resting <nowiki>[State when there is no stimulus presentation and no behavioral outputs]</nowiki> 
+** Attention 
+*** Top-down <nowiki>[Instructed to pay attention to something explicitly]</nowiki> 
+*** Bottom-up <nowiki>[something captures your attention, like a big bang or your name]</nowiki> 
+**** Orienting <nowiki>[The lower state of the bottom-up  or the pre-bottom up state]</nowiki> 
+*** Covert  <nowiki>[Implicit]</nowiki> 
+*** Overt <nowiki>[Explicit]</nowiki> 
+*** Selective <nowiki>[If you have two circles but asked to pay attention to only one of them]</nowiki> 
+**** Divided <nowiki> [Attending to more than one object or location]</nowiki> 
+*** Focused <nowiki> [Paying a lot of attention]</nowiki> 
+*** Sustained <nowiki> [Paying attention for a continuous time]</nowiki> 
+*** To a location <nowiki> [Spatial -- use the location attribute to specify to where the attention is directed]</nowiki> 
+*** Arousal <nowiki>{requireChild}</nowiki> 
+*** Alerting <nowiki> [Keeping the arousal up in order to respond quickly]</nowiki> 
+*** Drowsy 
+*** Excited 
+*** Neutral 
+
+
+'''Experiment context''' <nowiki>{extensionAllowed} [Describes the context of the whole experiment or large portions of it and also includes tags that are common across all events]</nowiki> 
+* With chin rest 
+* Sitting 
+* Standing 
+* Prone  <nowiki> [As in on a bed]</nowiki> 
+* Running 
+** Treadmill 
+* Walking 
+** Treadmill 
+* Indoors <nowiki> [Default]</nowiki> 
+** Clinic <nowiki> [Recording in a clinical setting such as in a hospital or doctor’s office]</nowiki> 
+** Dim Room 
+* Outdoors 
+** Terrain 
+*** Grass 
+*** Uneven 
+*** Boardwalk 
+*** Dirt 
+*** Leaves 
+*** Mud 
+*** Woodchip 
+*** Rocky 
+*** Gravel 
+*** Downhill 
+*** Uphill 
+* Motion platform <nowiki> [Subject is on a motion platform such as one that produces simulated car movements]</nowiki> 
+* Fixed screen 
+** Distance <nowiki>[Assuming static subject]</nowiki> 
+*** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} [Distance from subject eyes to the presentation screen for 30 cm from subject eyes to the monitor]</nowiki> 
+** Width resolution  
+*** <nowiki># {takesValue, isNumeric, unitClass=pixels} [Default units are  pixels] </nowiki> 
+** Height resolution 
+*** <nowiki># {takesValue, isNumeric, unitClass=pixels} [Default units are  pixels ]</nowiki> 
+* Real world 
+* Virtual world 
+
+'''Custom''' <nowiki>{requireChild, extensionAllowed} [This node can be used to organize events in an alternative (parallel) hierarchy. You can define your custom tags and hierarchies without any restriction under this node. These tags will still be matched to each other as for example  /Custom/Dance/Waltz is considered a subtype of /Custom/DanceExample.]</nowiki> 
+
+'''HED'''  <nowiki> {requireChild} [Hierarchical Event Descriptor]</nowiki> 
+* <nowiki># {takesValue, isNumeric} [HED specification version number: normally there is no need to specify the version number in the HED string since it will be matched by default to the most recent compliant version, but this tag can be used to specify the exact HED version the HED string was based on.]</nowiki> 
+
+'''Paradigm''' <nowiki>{requireChild, extensionAllowed}[See Tasks in http://www.cognitiveatlas.org/tasks and CogPo definitions of paradigms]</nowiki>   
+* Action imitation task 
+* Action observation task 
+* Acupuncture task 
+* Adult attachment interview 
+* Alternating runs paradigm 
+* Animal naming task 
+* Antisaccade-prosaccade task 
+* Attention networks test 
+* Attentional blink task 
+* Audio-visual target-detection task 
+* Autism diagnostic observation schedule 
+* Ax-cpt task   
+* Backward digit span task 
+* Backward masking 
+* Balloon analogue risk task - BART
+* Behavioral investment allocation strategy - BIAS
+* Behavioral rating inventory of executive function 
+* Benton facial recognition test 
+* Birmingham object recognition battery 
+* Block design test 
+* Block tapping test 
+* Boston naming test 
+* Braille reading task 
+* Breath-holding 
+* Breathhold paradigm 
+* Brixton spatial anticipation test 
+* California verbal learning test 
+* California verbal learning test-ii 
+* Cambridge face memory test 
+* Cambridge gambling task 
+* Cambridge neuropsychological test automated battery 
+* Catbat task 
+* Category fluency test 
+* Cattell culture fair intelligence test 
+* Chewing-swallowing 
+* Chimeric animal stroop task 
+* Choice reaction time task 
+* Choice task between risky and non-risky options 
+* Classical conditioning 
+* Clinical evaluation of language fundamentals-3 
+* Color trails test 
+* Color-discrimination task 
+* Color-word stroop task 
+* Complex span test 
+* Conditional stop signal task 
+* Conditioning paradigm 
+** Behavioral conditioning paradigm 
+** Classical conditioning paradigm 
+* Continuous performance task 
+* Continuous recognition paradigm 
+* Counting stroop task 
+* Counting-calculation 
+* Cued explicit recognition 
+* Cups task 
+* Deception task 
+* Deductive reasoning paradigm 
+* Deductive reasoning task 
+* Delayed discounting task 
+* Delayed match to sample task 
+* Delayed nonmatch to sample task 
+* Delayed recall test 
+* Delayed response task 
+** Delayed matching to sample paradigm 
+*** Sternberg paradigm 
+* Devils task 
+* Dichotic listening task 
+* Digit cancellation task 
+* Digit span task 
+* Digit-symbol coding test 
+* Directed forgetting task 
+* Divided auditory attention 
+* Divided auditory attention paradigm 
+* Doors and people test 
+* Dot pattern expectancy task 
+* Drawing
+* Drawing paradigm 
+* Dual-task paradigm 
+* Early social communications scales 
+* Eating paradigm 
+* Eating-drinking 
+* Embedded figures test 
+* Emotional regulation task 
+* Encoding paradigm 
+* Encoding task 
+* Episodic recall 
+* Episodic recall paradigm 
+* Eriksen flanker task 
+* Extradimensional shift task 
+* Eye Saccade paradigm 
+** Anti saccade paradigm 
+** Simple saccade paradigm 
+* Face monitor-discrimination 
+* Face n-back task 
+* Fagerstrom test for nicotine dependence
+* Film viewing 
+* Finger tapping task 
+* Fixation task 
+* Flashing checkerboard 
+* Flexion-extension 
+* Forward digit span task 
+* Free word list recall 
+* Glasgow coma scale 
+* Go-no-go task 
+* Grasping task 
+* Gray oral reading test - 4
+* Haptic illusion task 
+* Hayling sentence completion test 
+* Heat sensitization-adaptation 
+* Heat stimulation 
+* Hooper visual organization test 
+* ID screening <nowiki> [Visual examination of multiple fields of an ID or document to detect invalid or suspicious fields. For example at a security checkpoint.]</nowiki>
+* Imagined emotion
+* Imagined movement 
+* Imagined objects-scenes
+* Instructed movement
+* Immediate recall test 
+* Inductive reasoning aptitude 
+* International affective picture system 
+* Intradimensional shift task 
+* Ishihara plates for color blindness 
+* Isometric force 
+* Item recognition paradigm 
+** Serial item recognition paradigm 
+* Item recognition task 
+* Kanizsa figures 
+* Keep-track task 
+* Letter comparison 
+* Letter fluency test 
+* Letter naming task 
+* Letter number sequencing 
+* Lexical decision task 
+* Listening span task 
+* Macauthur communicative development inventory
+* Machine failure detection task
+* Matching familiar figures test 
+* Matching pennies game 
+* Maudsley obsessive compulsive inventory 
+* Mechanical stimulation 
+* Memory span test 
+* Mental rotation task 
+* Micturition task 
+* Mini mental state examination
+* Mirror tracing test 
+* Mismatch negativity paradigm 
+* Mixed gambles task 
+* Modified erikson scale of communication attitudes 
+* Morris water maze 
+* Motor sequencing task 
+* Music comprehension-production 
+* N-back task 
+** Letter n-back task 
+* Naming 
+** Covert 
+** Overt 
+* Nine-hole peg test 
+* Non-choice task to study expected value and uncertainty 
+* Non-painful electrical stimulation 
+* Non-painful thermal stimulation 
+* Nonword repetition task 
+* Object alternation task 
+* Object-discrimination task 
+* Oculomotor delayed response 
+* Oddball discrimination paradigm 
+** Auditory oddball paradigm 
+** Visual oddball paradigm 
+*** Rapid serial visual presentation 
+* Oddball task 
+* Olfactory monitor-discrimination 
+* Operation span task 
+* Orthographic discrimination 
+* Paced auditory serial addition test 
+* Pain monitor-discrimination task 
+* Paired associate learning 
+* Paired associate recall 
+* Pantomime task 
+* Parrott scale 
+* Passive listening 
+* Passive viewing 
+* Pattern comparison 
+* Perturbed driving
+* Phonological discrimination 
+* Picture naming task 
+* Picture set test 
+* Picture-word stroop task 
+* Pitch monitor-discrimination 
+* Pointing 
+* Porteus maze test 
+* Positive and negative affect scale 
+* Posner cueing task 
+* Probabilistic classification task 
+* Probabilistic gambling task 
+* Probabilistic reversal learning 
+* Pseudoword naming task 
+* Psychomotor vigilance task
+* Pursuit rotor task 
+* Pyramids and palm trees task 
+* Rapid automatized naming test 
+* Rapid serial object transformation 
+* Reading - Covert
+* Reading - Overt
+* Reading paradigm 
+** Covert braille reading paradigm 
+** Covert visual reading paradigm 
+* Reading span task 
+* Recitation-repetition - Covert
+* Recitation-repetition - Overt
+* Remember-know task 
+* Response mapping task 
+* Rest
+** Rest eyes open
+** Rest eyes closed
+* Retrieval-induced forgetting task 
+* Reversal learning task 
+* Reward task 
+* Rey auditory verbal learning task 
+* Rey-ostereith complex figure test 
+* Reynell developmental language scales 
+* Rhyme verification task 
+* Risky gains task 
+* Rivermead behavioural memory test 
+* <nowiki>[extend here]</nowiki> 
+
+'''Unit classes''' 
+* acceleration <nowiki>{default=cm-per-s2}</nowiki> 
+** m-per-s2 
+** cm-per-s2 
+* currency <nowiki>{default=$}</nowiki> 
+** dollars 
+** $ 
+**points 
+**fraction 
+* angle <nowiki>{default=radians}</nowiki> 
+** degrees 
+** degree 
+** radian 
+** radians 
+* frequency <nowiki>{default=Hz}</nowiki> 
+** Hz 
+** mHz 
+** Hertz 
+** kHz 
+* intensity <nowiki>{default=dB}</nowiki> 
+** dB 
+* jerk <nowiki>{default=cm-per-s3}</nowiki> 
+** m-per-s3 
+** cm-per-s3 
+* luminousIntensity <nowiki>{default=cd}</nowiki> 
+** candela 
+** cd 
+* memorySize <nowiki>{default=mb}</nowiki> 
+** mb 
+** kb 
+** gb 
+** tb 
+* physicalLength <nowiki>{default=cm}</nowiki> 
+** m 
+** cm 
+** km 
+** mm 
+** feet 
+** foot 
+** meter 
+** meters 
+** mile 
+** miles 
+* pixels <nowiki>{default=px}</nowiki> 
+** pixels  
+** px 
+** pixel 
+* speed <nowiki>{default=cm-per-s}</nowiki> 
+** m-per-s 
+** mph 
+** kph 
+** cm-per-s 
+* time <nowiki>{default=s}</nowiki> 
+** s 
+** second 
+** seconds
+** centiseconds
+** centisecond
+** cs
+** hour:min 
+** day 
+** days 
+** ms 
+** milliseconds
+** millisecond
+** minute 
+** minutes 
+** hour 
+** hours 
+* area <nowiki>{default=cm2}</nowiki> 
+**m2 
+** cm2 
+** km2 
+** pixels2 
+** px2 
+** pixel2 
+** mm2 
+* volume <nowiki>{default=cm3}</nowiki> 
+** m3 
+** cm3 
+** mm3 
+** km3 
+!# end hed 
+
+'''Attribute Definitions:'''
+* extensionAllowed <nowiki>[users can add (unlimited levels of) child nodes under this tag.]</nowiki> 
+* requireChild  <nowiki>[One of its descendants must be chosen to tag an event.]</nowiki> 
+* takesValue <nowiki>[The tag name is the "#" character, and this character will be replaced with the user's input. The input is a string.] </nowiki> 
+* isNumeric <nowiki>[The tag name is the "#" character, and this character will be replaced with the user's input. The input is numerical.]</nowiki>  
+*  required <nowiki>[Shown at the top of the events view in the order given by the position attribute. Checked for at the end if the user chooses "done".]</nowiki> 
+* recommended  <nowiki>[Shown below the required tags in the events view in the order given by the position attribute.]</nowiki> 
+* position <nowiki>[Used to specify the order of the required and recommended tags compared separately from each other. It expects an integer and the order can start at 0 or 1. It just checks for comparison. Required or recommended tags without this attribute or with negative position will be shown after the others.]</nowiki> 
+* unique <nowiki>[Only one of this tag or its descendants can be used within a single tag group or event.]</nowiki> 
+* predicateType <nowiki> [One of propertyOf, subclassOf, passThrough -- used to facilitate mapping to OWL or RDF.]</nowiki> 
+* default <nowiki>[Default value -- mostly used for unitClasses.]</nowiki> 

--- a/HED-schema-revision
+++ b/HED-schema-revision
@@ -51,12 +51,6 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 '''Item''' <nowiki>{extensionAllowed}</nowiki>
 * Object <nowiki> {extensionAllowed} [Visually discernable objects. This item excludes sounds that are Items but not objects]</nowiki>
 ** Inanimate
-*** Bell
-*** Buzzer
-*** Cash register
-*** Clicker
-*** Fire alarm
-*** Siren
 ** Vehicle 
 ** Person 
 ** Animal
@@ -73,32 +67,16 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Whole face without hair 
 ** Cut-out 
 ** Parts only 
-*** Nose 
-*** Lips 
-*** Chin 
-*** Eyes 
 * Symbolic <nowiki> [Something that has a meaning, could be linguistic or not such as a stop signs.]</nowiki> 
 ** Braille character 
 ** Sign <nowiki>[Like the icon on a stop sign. This should not to be confused with the actual object itself.] </nowiki> 
-*** Traffic 
-**** Speed limit 
-***** <nowiki># {takesValue, isNumeric, unitClass=speed} [Always give units e.g. mph or kph]</nowiki> 
 ** Character  
-*** Digit 
-*** Pseudo-character <nowiki> [Alphabet-like but not really]</nowiki> 
-*** Letter <nowiki> [Authograph or valid letters and numbers such as A or 5]</nowiki> 
-**** <nowiki># {takesValue}</nowiki> 
 ** Composite <nowiki>[Has multiple of the above on it</nowiki> 
-* Multimedia
+* Media
 ** Photograph
-*** Natural scene 
-**** Aerial 
-**** Satellite 
 ** Drawing <nowiki>[Cartoon or sketch]</nowiki> 
-*** Line drawing 
 ** Film clip  
 ** Sound clip
-** Commercial TV 
 ** Animation 
 ** Movie
 
@@ -111,32 +89,8 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Tone 
 ** Siren 
 ** Music 
-*** Chord sequence 
-*** Vocal 
-*** Instrumental
-*** Tone
-*** Genre
 ** Noise 
-*** White 
-*** Colored <nowiki>[Not white --- for example a 1/f spectrum]</nowiki> 
 ** Real world <nowiki> [For example people walking or machines operating]</nowiki> 
-*** Pedestrian 
-*** Footsteps 
-**** Walking 
-**** Running 
-*** Noisemaker 
-*** Construction noise 
-*** Machine 
-*** Vehicle 
-**** Horn 
-**** Aircraft 
-***** Airplane 
-***** Helicopter 
-**** Train 
-**** Cart 
-**** Car alarm 
-**** Car 
-**** Bicycle 
 ** Nonverbal vocal 
 *** Emotional 
 **** Crying 
@@ -148,31 +102,9 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Yawn 
 ** Nonvocal <nowiki> [A car engine or gears grinding --- anything that is not made by a human or an animal]</nowiki> 
 *** Engine 
+
 '''Attribute''' <nowiki>{requireChild, extensionAllowed}</nowiki>
 * ID <nowiki>{requireChild}[Tag to identify any aspect of an event. Use parentheses to group an ID Value tag with an ID Type tag to qualify the kind of ID that the value represents.]</nowiki>
-** Collection <nowiki>[Identifier for an object in a specified collection]</nowiki>
-*** IAPS <nowiki>[International Affective Picture System]</nowiki> 
-**** # <nowiki>{takesValue}</nowiki>
-*** IADS <nowiki> [International Affective Digital Sounds]</nowiki> 
-**** # <nowiki>{takesValue}</nowiki>
-*** SAM <nowiki> [The Self-Assessment Manikin]</nowiki> 
-**** # <nowiki>{takesValue}</nowiki>
-** Group <nowiki>[ID that identifies a group of events associated with each other.]</nowiki>
-*** # <nowiki>{takesValue}</nowiki>
-** Index <nowiki>{requireChild}[Use this tag with a value for IDs that don't fall into another category.]</nowiki>
-*** # <nowiki>{takesValue}</nowiki>
-** Local <nowiki>[For IDs only defined in the scope of a single event. The local ID 5 in events 1 and 2 may refer to two different objects. The global IDs  directly under ID tag refer to the same object through the whole experiment]</nowiki>
-*** # <nowiki>{takesValue}</nowiki>
-** Participant <nowiki>[ID identifies a subject.]</nowiki>
-*** # <nowiki>{takesValue}</nowiki>
-** Permutation <nowiki>[ID is used to identify an ordering as for example to indicate block order in an experimental design.]</nowiki>
-*** # <nowiki>{takesValue}</nowiki>
-** Reference object <nowiki>[ID is used to a reference object to specify location with respect to.]</nowiki>
-*** # <nowiki>{takesValue}</nowiki>
-** State <nowiki>[ID is used to identify a group of events that are changing the state of a variable as for example when the onset means the offset of any other and a change in the state]</nowiki>
-*** # <nowiki>{takesValue}</nowiki>
-** Synchronization <nowiki>[ID is used to tag an event for synchronizing data streams.]</nowiki>
-*** # <nowiki>{takesValue}</nowiki>
 * Parameters <nowiki>{predicateType=propertyOf}</nowiki> 
 **<nowiki># {takesValue} [Experiment parameters in some a string. Do not used quotes.]</nowiki> 
 * Sensory presentation <nowiki>{requireChild}[Object manifestation]</nowiki>
@@ -182,141 +114,19 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Taste
 ** Visual
 *** Rendering type <nowiki>{requireChild, predicateType=passThrough}</nowiki> 
-**** Screen 
-***** Head-mounted display
-***** View port <nowiki> [Two or more views on the same object --- for example one from top one from street view]</nowiki> 
-***** 2D 
-***** 3D 
-***** Movie 
-****** Video-tape 
-****** Motion-capture <nowiki>[Stick figure of motion capture of someone else]</nowiki> 
-******* Point light 
-******* Stick figure 
-******* Outline 
-****** Flickering 
-****** Steady state 
-**** Real-world 
-**** LED <nowiki>[Stimulus is turning on/off one or a few LEDs]</nowiki> 
-
 * Spatial <nowiki>{requireChild}</nowiki>
 ** Direction <nowiki>{requireChild} [Coordinate system is inferred from Attribute/Location. To specify a vector combine subnodes with number --- for example Attribute/Top/10, Attribute/Direction/Left/5 to create a vector with coordinates 10 and 5]</nowiki> 
-*** Bottom 
-**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki>
-*** Left 
-**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-*** Right  
-**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki>  
-*** Top <nowiki> [Combine Attribute/Direction/Top and Attribute/Direction/Left to mean the upper left]</nowiki> 
-**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-*** Angle <nowiki>[Clockwise angle in degrees from vertical]</nowiki> 
-**** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise angle in degrees from vertical]</nowiki> 
-*** North 
-**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-*** South 
-**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-*** East 
-**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-*** West 
-**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-*** Forward <nowiki> [Like a car moving forward]</nowiki> 
-*** Backward <nowiki>[Like a car moving backward]</nowiki> 
-
 ** Location {requireChild} <nowiki>[Spot or center of an area. Use Area were you are referring to something with significant extent and emphasizing its boundaries, like a city]</nowiki> 
-*** <nowiki># {takesValue} [location label]</nowiki> 
-*** Lane <nowiki>[For example a car lane]</nowiki> 
-**** Cruising  
-**** Leftmost 
-**** Left of expected 
-**** Oncoming 
-**** Passing <nowiki>[The lane that cars use to take over other cars]</nowiki> 
-**** Rightmost 
-**** Right of expected 
-*** Real-world coordinates <nowiki>{requireChild}</nowiki> 
-**** Room 
-***** xyz <nowiki> {requireChild} [have a subnode, e.g. Attribute/Location/Real-world coordinates/Room/xyz/[10 50 30]]</nowiki> 
-****** <nowiki># {takesValue}</nowiki> 
-*** Reference frame <nowiki>{requireChild}</nowiki> 
-**** Relative to participant
-***** Azimuth <nowiki>{requireChild}</nowiki> 
-****** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise with units preferably in degrees]</nowiki>  
-***** Back 
-***** Distance <nowiki>{requireChild}</nowiki> 
-****** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} [Distance is in meters by default]</nowiki> 
-****** Far
-****** Moderate  
-****** Near 
-***** Elevation <nowiki>{requireChild}</nowiki> 
-****** <nowiki># {takesValue, isNumeric, unitClass=angle} [Preferably in degrees]</nowiki> 
-***** Front 
-***** Left 
-***** Right 
-**** Specified absolute reference 
-*** Screen <nowiki>[Specify displacements from each subnode in pixels or degrees or meters. Specify units such as Attribute/Spatial/Location/Screen/Top/12 px]</nowiki> 
-**** Angle  
-***** <nowiki># {takesValue, isNumeric, unitClass=angle} [Clockwise angle in degrees from vertical]</nowiki> 
-**** Bottom 
-***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-**** Center 
-***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki>
-**** Center displacement 
-***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength} [Displacement from screen center, in any direction, in degrees, cm, or other lengths]</nowiki> 
-***** Horizontal 
-****** <nowiki># {takesValue, isNumeric, unitClass=angle,  unitClass=physicalLength} [Displacement from screen center in any direction]</nowiki> 
-***** Vertical 
-****** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength}[Displacement from screen center in any direction]</nowiki>  
-**** Left 
-***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-**** Right  
-**** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-**** Top <nowiki>[You can combine Attribute/Location/Top and Attribute/Location/Left to designate UpperLeft and so on]</nowiki> 
-***** <nowiki># {takesValue, isNumeric, unitClass=angle, unitClass=physicalLength, unitClass=pixels}</nowiki> 
-** Object orientation <nowiki>{requireChild}</nowiki> 
-*** Rotated 
-**** Degrees <nowiki>{requireChild}</nowiki> 
-***** <nowiki>#{takesValue, isNumeric, unitClass=angle}[Preferably in degrees]</nowiki> 
-** Object side <nowiki>{requireChild} [Could be the left,  right, or both sides of a person or a vehicle]</nowiki> 
-*** Back 
-*** Bottom 
-*** Bow <nowiki>[Front of a ship]</nowiki> 
-*** Driver side <nowiki>[Side of a car]</nowiki> 
-*** Front 
-*** Left 
-*** Passenger side <nowiki>[Side of a car]</nowiki> 
-*** Port 
-*** Right 
-*** Stern <nowiki>[Back of the ship]</nowiki>
-*** Starboard 
-*** Top 
 ** Size <nowiki>{requireChild}</nowiki>
-*** Angle<nowiki>{requireChild}</nowiki> 
-**** <nowiki># {takesValue, isNumeric, unitClass=angle} [In degrees or other units of angle]</nowiki> 
-*** Area <nowiki>{requireChild}</nowiki> 
-**** <nowiki># {takesValue, isNumeric, unitClass=area}</nowiki>
-*** Height
-**** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} [Default units are meters]</nowiki>
-*** Length<nowiki>{requireChild}</nowiki> 
-**** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} [In meters or other units of length ]</nowiki> 
-*** Volume <nowiki>{requireChild}</nowiki> 
-**** <nowiki># {takesValue, isNumeric, unitClass=volume} [In cubic-meters or other units of volume]</nowiki> 
-*** Width
-**** <nowiki># {takesValue, isNumeric, unitClass=physicalLength} </nowiki><nowiki>[in meters]</nowiki> 
 * Temporal <nowiki>{requireChild}</nowiki>
 ** Duration <nowiki>{requireChild} [An offset that is implicit after duration time passed from the onset]</nowiki>
-*** <nowiki># {takesValue, isNumeric, unitClass=time}</nowiki>
 ** Onset <nowiki>[Default]</nowiki> 
 ** Offset
 ** Repetition <nowiki>{requireChild} [When the same type of event such as a fixation on the exact same object happens multiple times and it might be necessary to distinguish the first look vs. others]</nowiki> 
-*** <nowiki># {takesValue, isNumeric} [Number starting from 1 where 1 indicates the first occurrence and 2 indicates the second occurrence]</nowiki> 
 ** Response start delay <nowiki>[The time interval between this (stimulus) event and the start of the response event specified, usually by grouping with the event ID of the response start event.]</nowiki>
-*** <nowiki># {takesValue, unitClass=time}</nowiki>
 ** Response end delay <nowiki>[The time interval between this (stimulus) event and the end of the response event specified, usually by grouping with the event ID of the response end event.]</nowiki>
-*** <nowiki># {takesValue, unitClass=time}</nowiki>
 ** Rate <nowiki>[Number of occurrences in a unit of time.]</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=frequency} [In Hz]</nowiki> 
 ** Uncertainty <nowiki> {requireChild} [Use to specify the amount of uncertainty in the timing of the event. Please notice that this is different from Attribute/Probability tag which relates to the occurrence of event and can be interpretative as the integral of probability density across a distribution whose shape (temporal extent) is specified by Attribute/Temporal uncertainty]. </nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=time} [implies that the temporal uncertainty is a uniform distribution with the amount of time provided, extending on both side. E.g. "0.5 s" specifies a 1-second range centered at event latency.</nowiki> 
-*** Standard deviation <nowiki>{requireChild} [implies that the distribution of temporal uncertainty is Gaussian with the provided standard deviation (in seconds).]</nowiki> 
-**** <nowiki># {takesValue, isNumeric, unitClass=time}</nowiki>
 * Imagined <nowiki>[This is used to identity that the (sub)event only happened in participant's imagination, e.g.  imagined movements in motor imagery paradigms.]</nowiki>
 * Condition <nowiki>{requireChild} [Specifies the value of an independent variable (number of letters, N, in an N-back task) or function of independent variables that is varied or controlled for in the experiment.  This attribute is often specified at the task level and can be associated with specification of an experimental stimulus or an experiment context (e.g. 1-back, 2-back conditions in an N-back task, or changing the target type from faces to houses in a Rapid Serial Visual Presentation, or RSVP, task.)]</nowiki>
 ** # <nowiki>{takesValue} [the condition]</nowiki> 
@@ -327,167 +137,68 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Time out 
 *** Missed <nowiki>[Participant failed or could not have perceived the instruction due to their eyes being off-screen or a similar reason. Not easy to deduce this but it is possible]</nowiki> 
 ** Inappropriate <nowiki>[A choice that is not allowed such as moving a chess piece to a location it should not go based on game rules]</nowiki>
-
 * Social <nowiki>[Involving interactions among multiple agents such as humans or dogs or robots]</nowiki> 
 * Peak <nowiki>[Peak velocity or  acceleration or jerk]</nowiki>
 * Item count <nowiki>{requireChild} [Number of items for example when there are 3 cars and they are identified as a single item]</nowiki> 
-** <nowiki># {takesValue, isNumeric} [Numeric value of number of items #]</nowiki> 
-** <nowiki><=# {takesValue, isNumeric} [Number of items less than or equal to #]</nowiki> 
-** <nowiki>>=# {takesValue, isNumeric} [Number of items  more than or equal to #]</nowiki> 
 * Auditory <nowiki></nowiki> 
 ** Frequency <nowiki>{requireChild}</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=frequency} [In HZ]</nowiki> 
 ** Loudness <nowiki>{requireChild}</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=intensity} [in dB]</nowiki> 
 ** Ramp up <nowiki>[Increasing in amplitude]</nowiki> 
 ** Ramp down <nowiki>[Decreasing in amplitude]</nowiki> 
 * Blink
-** Time shut <nowiki>{requireChild} [The amount of time the eyelid remains closed (typically measured as 90% of the blink amplitude), in seconds.]</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=time, default=s}</nowiki> 
-** Duration <nowiki>{requireChild} [Duration of blink, usually the half-height blink duration in seconds taken either from base or zero of EEG signal. For eye-trackers, usually denotes interval when pupil covered by eyelid.]</nowiki>
-***<nowiki># {takesValue, isNumeric, unitClass=time, default=s}</nowiki> 
-** PAVR <nowiki>{requireChild} [Amplitude-Velocity ratio, in centiseconds]</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=time, default=centiseconds}</nowiki> 
-** NAVR <nowiki>{requireChild} [Negative Amplitude-Velocity ratio, in centiseconds]</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=time, default=centiseconds}</nowiki> 
+** Time shut <nowiki>{requireChild} [The amount of time the eyelid remains closed (typically measured as 90% of the blink amplitude), in seconds.]</nowiki> *** <nowiki># {takesValue, isNumeric, unitClass=time, default=s}</nowiki> 
+** Duration <nowiki>{requireChild} [Duration of blink, usually the half-height blink duration in seconds taken either from base or zero of EEG signal. For eye-trackers, usually denotes interval when pupil covered by eyelid.]</nowiki>***<nowiki># {takesValue, isNumeric, unitClass=time, default=s}</nowiki> 
+** PAVR <nowiki>{requireChild} [Amplitude-Velocity ratio, in centiseconds]</nowiki> *** <nowiki># {takesValue, isNumeric, unitClass=time, default=centiseconds}</nowiki> 
+** NAVR <nowiki>{requireChild} [Negative Amplitude-Velocity ratio, in centiseconds]</nowiki> *** <nowiki># {takesValue, isNumeric, unitClass=time, default=centiseconds}</nowiki>
 * Visual <nowiki></nowiki>
 ** Bistable 
 ** Background 
 ** Foreground 
 ** Up-down separated <nowiki>[Stimuli presented both at the top and the bottom of fovea]</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=angle} [Angle of separation in degrees by default]</nowiki> 
 ** Bilateral <nowiki>[For bilateral visual field stimulus presentations]</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=angle} [Angle of separation in degrees by default] </nowiki> 
 ** Motion 
-*** Down    
-**** <nowiki># {takesValue, isNumeric, unitClass=speed} [e.g. 3 degrees-per-second]</nowiki> 
-*** Up 
-**** <nowiki># {takesValue, isNumeric, unitClass=speed} [e.g. 3 degrees-per-second]</nowiki> 
-*** Horizontal 
-**** Right   
-***** <nowiki># {takesValue, isNumeric, unitClass=speed} [e.g. 3 degrees-per-second]</nowiki> 
-**** Left 
-***** <nowiki># {takesValue, isNumeric, unitClass=speed} [e.g. 3 degrees-per-second]</nowiki> 
-*** Oblique 
-**** Clock face 
-***** <nowiki>#  {takesValue, unitClass=time} [For example  4:30]</nowiki> 
 ** Fixation point 
 ** Luminance <nowiki>{requireChild}</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=luminousIntensity}[In candelas by default]</nowiki> 
 ** Color <nowiki>{requireChild}</nowiki> 
-*** Dark 
-*** Light 
-*** Aqua <nowiki>[These are CSS 3 basic color names]</nowiki> 
-*** Black 
-*** Fuchsia  
-*** Gray 
-*** Lime  
-*** Maroon 
-*** Navy 
-*** Olive  
-*** Purple  
-*** Silver  
-*** Teal  
-*** White  
-*** Yellow 
-*** Red 
-**** <nowiki># {takesValue, isNumeric} [R value of RGB between 0 and 1]</nowiki> 
-*** Blue 
-**** <nowiki># {takesValue, isNumeric} [B value of RGB between 0 and 1]</nowiki> 
-*** Green 
-**** <nowiki># {takesValue, isNumeric} [G value of RGB between 0 and 1]</nowiki> 
-*** Hue <nowiki>{requireChild}</nowiki> 
-**** <nowiki># {takesValue, isNumeric} [H value of HSV between 0 and 1]</nowiki> 
-*** Saturation <nowiki>{requireChild}</nowiki> 
-**** <nowiki># {takesValue, isNumeric} [S value of HSV between 0 and 1]</nowiki> 
-*** Value <nowiki>{requireChild}</nowiki> 
-**** <nowiki># {takesValue, isNumeric} [V value of HSV between 0 and 1]</nowiki> 
-*** Achromatic <nowiki>[Indicates gray scale]</nowiki> 
-**** <nowiki># {takesValue, isNumeric} [White intensity between 0 and 1]</nowiki> 
+
 * Nonlinguistic <nowiki>[Something that conveys meaning without using words such as the iconic pictures of a man or a woman on the doors of restrooms. Another example is a deer crossing sign with just a picture of jumping deer.]</nowiki> 
 * Semantic <nowiki>[Like in priming or in congruence]</nowiki> 
 * Language 
 ** Unit <nowiki>{predicateType=passThrough}</nowiki> 
-*** Phoneme 
-*** Syllable 
-*** Word 
-**** Noun 
-***** Proper <nowiki>[A proper noun that  refers to a unique entity  such as London or Jupiter]</nowiki> 
-***** Common <nowiki>[A noun that refers to a class of entities such as cities or planets or corporations  such as a Dog or a Skyscraper]</nowiki> 
-**** Verb 
-**** Adjective 
-**** Pseudoword 
-**** <nowiki># {takesValue} [Actual word]</nowiki> 
-*** Sentence 
-**** Full 
-**** Partial 
-**** <nowiki># {takesValue} [Actual sentence]</nowiki> 
-*** Paragraph 
-**** <nowiki># {takesValue} [Actual paragraph]</nowiki> 
-*** Story <nowiki>[Multiple paragraphs making a detailed account]</nowiki> 
 ** Family <nowiki>{predicateType=passThrough}</nowiki> 
-*** Asian
-**** Chinese 
-**** Japanese 
-*** Latin
-**** English 
-**** German 
-**** French 
+
 * Induced <nowiki>[Such as inducing emotions or keeping someone awake or in a coma with an external intervention]</nowiki> 
 * Emotional 
 ** Arousal <nowiki>[Only in the context of 2D emotion representation]</nowiki> 
-*** <nowiki># {takesValue, isNumeric} [A value between -1 and 1]</nowiki> 
 ** Positive valence <nowiki> [Valence by itself can be the name of an emotion such as sadness so this tag distinguishes the type of emotion]</nowiki> 
-*** <nowiki># {takesValue, isNumeric} [Ranges from 0 to 1]</nowiki> 
 ** Negative valence 
-*** <nowiki># {takesValue, isNumeric}[Ranges from 0 to 1]</nowiki> 
 * Priming 
 ** Motoric 
 ** Emotional 
-** Perceptual 
+** Perceptual
 * Subliminal 
 ** Unmasked 
 ** Masked 
-*** Forward 
-*** Backward 
 * Supraliminal <nowiki>[By default this is assumed about each stimulus]</nowiki> 
 * Liminal <nowiki>[At the 75%-25% perception threshold]</nowiki> 
 * Probability <nowiki> [Use to specify the level of certainty about the occurrence of the event. Use either numerical values as the child node or 'low', 'high', etc.]</nowiki> 
-
 * Presentation <nowiki>{requireChild}[Attributes associated with visual, auditory, tactile, etc. presentation of an stimulus]</nowiki>
 ** Fraction <nowiki>{requireChild} [the fraction of presentation of an Oddball or Expected stimuli to the total number of same-class presentations, e.g. 10% of images in an RSVP being targets] </nowiki> 
-*** <nowiki># {takesValue, isNumeric}</nowiki>
 ** Cued <nowiki>[what is presented is cued to the presentation of something else] </nowiki> 
-** Background <nowiki>[presented in the background such as background music, background image, etc. The main factor here is that background presentations are to be ignored, e.g. ignore math question auditory stimuli.] </nowiki> 
+** Background <nowiki>[presented in the background such as background music, background image, etc. The main factor here is that background presentations are to be ignored, e.g. ignore math question auditory stimuli.] </nowiki>
 * Intended effect <nowiki>[This tag is to be grouped with Participant/Effect/Cognitive to specify the intended cognitive effect (of the experimenter). This is to differentiate the resulting group with Participant/Effect which specifies the actual effect on the participant. For example, in an RSVP experiment if an image is intended to be perceived as a target, (Participant/Effect/Cognitive/Target, Attribute/Intended effect) group is added. If the image was perceived by the subject as a target (e.g. they pressed a button to indicate so), then the tag Participant/Effect/Cognitive/Target is also added: Participant/Effect/Cognitive/Target, (Participant/Effect/Cognitive/Target, Attribute/Intended effect). otherwise the Participant/Effect/Cognitive/Target tag is not included outside of the group.]</nowiki>
 * Instruction <nowiki> [This tag is placed in events of type Event/Category/Experimental stimulus/Instruction, grouped with one or more Action/ tags to replace the detailed specification XXX in Event/Category/Experimental stimulus/Instruction/XXX) in previous versions. Usage example:  Event/Category/Experimental stimulus/Instruction, (Action/Fixate, Attribute/Instruction) ]</nowiki>
 * Participant indication <nowiki> [This tag is placed in events of type Event/Category/Participant response and grouped with Participant/Effect/Cognitive/.. tags to specify the type of cognitive effect the participant has experienced. For example, in an RSVP paradigm, the subject can indicate the detection of a target with a button press. The HED string associated with this button press must include (Attribute/Participant indication, Participant/Effect/Cognitive/Target,...)]</nowiki>
 * Path <nowiki>{requireChild}</nowiki> 
 ** Velocity  <nowiki>[Use Attribute/Temporal/Onset or Attribute/Temporal/Offset to specify onset or offset]</nowiki> 
-*** <nowiki># {takesValue, isNumeric, unitClass=speed} [Numeric value with default units of m-per-s]</nowiki> 
 ** Acceleration 
-*** <nowiki># {takesValue, isNumeric, unitClass=acceleration} [Numeric value with default units of m-per-s2] </nowiki> 
 ** Jerk 
-*** <nowiki># {takesValue, isNumeric, unitClass=jerk} [Numeric value with default units of m-per-s3] </nowiki> 
 ** Constrained <nowiki>[For example a path cannot cross some region]</nowiki> 
 * File <nowiki>{requireChild} [File attributes]</nowiki> 
 ** Name 
 ** Size 
 ** Number
-*** <nowiki># {takesValue, isNumeric, unitClass=memorySize} [Numeric value with default units of mb]</nowiki> 
-** <nowiki># {takesValue, isNumeric}[Number of files]</nowiki> 
 * Object control <nowiki>{requireChild} [Specifies control such as for a vehicle]</nowiki> 
-** Perturb 
-** Collide 
-** Near miss <nowiki>[Almost having an accident resulting in negative consequences]</nowiki> 
-** Correct position <nowiki>[After a lane deviation or side of the walkway]</nowiki> 
-** Halt <nowiki>[Time at which speed becomes exactly zero]</nowiki> 
-** Brake 
-** Shift lane 
-** Cross <nowiki>[Crossing in front of another object such as a vehicle]</nowiki> 
-** Pass by <nowiki>[Passing by another object or the participant]</nowiki> 
-** Accelerate
-** Decelerate
 * Association <nowiki>{requireChild}</nowiki> 
 ** Another person <nowiki>[Item such as a cup belonging to another person]</nowiki> 
 ** Same person <nowiki>[Item such as a cup belonging to the participant]</nowiki> 
@@ -511,14 +222,9 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Burp 
 ** Drop <nowiki>[For example something  drops from subject’s hand]</nowiki>
 * Make fist
-** Open and close <nowiki>[Continue to open and close the fist, for example in motor imagery paradigms.]</nowiki>
 * Curl toes
-** Open and close <nowiki>[Continue to curl and uncurl toes, for example in motor imagery paradigms.]</nowiki>
+* Open and close <nowiki>[Continue to curl and uncurl toes, for example in motor imagery paradigms.]</nowiki>
 * Button press <nowiki>{extensionAllowed}</nowiki> 
-** Touch screen 
-** Keyboard 
-** Mouse 
-** Joystick 
 * Button hold <nowiki>[Press a button and keep it pressed]</nowiki> 
 * Button release 
 * Cross boundary 
@@ -529,21 +235,8 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 * Eye saccade <nowiki> [Use Attribute/Peak for the middle of saccade and Attribute/Temporal/Onset for the start of a saccade]</nowiki> 
 * Eye fixation 
 * Eye blink
-** Left base <nowiki>[The time of the first detectable eyelid movement on closing.]</nowiki>
-** Left zero <nowiki>[The last time at which the EEG/EOG signal crosses zero during eyelid closing.]</nowiki>
-** Left half height <nowiki>[The time at which the EEG/EOG signal reaches half maximum height during eyelid closing.]</nowiki>
-** Max <nowiki>[The time at which the eyelid is the most closed.]</nowiki> 
-** Right half height <nowiki>[The time at which the EEG/EOG signal reaches half maximum height during eyelid opening.]</nowiki>
-** Right zero <nowiki>[The first time at which the EEG/EOG signal crosses zero during eyelid opening.]</nowiki>
-** Right base <nowiki>[The time of the last detectable eyelid movement on opening.]</nowiki>
 * Eye close <nowiki>[Close eyes and keep closed for more than approximately 0.1 s]</nowiki> 
-** Keep <nowiki>[Keep the eye closed. If a value is provided it indicates the duration for this.]</nowiki> 
-*** # <nowiki>[the duration (by default in seconds) that they keep their eye closed.]{takesValue, isNumeric, unitClass=time}</nowiki>
 * Eye open <nowiki>[Open eyes and keep open for more than approximately 0.1 s]</nowiki>
-** Keep <nowiki>[Keep the eye open. If a value is provided it indicates the duration for this.]</nowiki> 
-*** # <nowiki>[the duration (by default in seconds) that they keep their eye open.]{takesValue, isNumeric, unitClass=time}</nowiki>
-*** With blinking <nowiki>[Default. Allow blinking during the eye-open period.]</nowiki>
-*** Without blinking <nowiki>[Without blinking during the eye-open period.]</nowiki>
 * Turn <nowiki>[Change in direction of movement or orientation. This includes both turn during movement on a path and also rotations such as head turns]</nowiki> 
 * Point 
 * Push 
@@ -624,127 +317,34 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Not meaningful 
 *** Newly learned meaning 
 *** Reward 
-**** Low 
-**** Medium 
-**** High 
-**** <nowiki># {takesValue, isNumeric, unitClass=currency} [Monetary values in some currency such as $10, or the ratio of the reward to the maximum possible (3 of max 10 becomes 0.3), or number Points]</nowiki> 
 *** Penalty 
-**** Low 
-**** Medium 
-**** High 
-**** <nowiki># {takesValue, isNumeric, unitClass=currency} [Absolute monetary values in some currency, for example $1, or the ratio of the reward to the maximum possible (3 of max 10 becomes 0.3), or number of Points]</nowiki> 
 *** Error 
-**** Self originated 
-**** Other originated 
-***** Human 
-***** Non-human 
-**** Expected 
-**** Unexpected 
-**** Planned <nowiki>[The error feedback was given regardless of the validity of subject response as in a yoked design] </nowiki> 
 *** Threat 
-**** To self 
-**** To others 
-***** Close 
 *** Warning <nowiki>[As in a warning message that you are getting too close to the shoulder in a driving task]</nowiki> 
 *** Oddball <nowiki> [Unexpected or infrequent]</nowiki> 
-**** One stimulus <nowiki>[Only oddballs are present but no frequent stimuli exist. See http://dx.doi.org/10.1016/0167-8760(96)00030-X]</nowiki> 
-**** Two stimuli <nowiki>[There are non-targets and targets. See http://dx.doi.org/10.1016/0167-8760(96)00030-X]</nowiki> 
-**** Three stimuli <nowiki>[There are regular non-targets and targets and infrequent non-targets, see http://dx.doi.org/10.1016/0167-8760(96)00030-X]</nowiki> 
-**** Silent counting 
-**** Button pressing for target 
-**** Button pressing for all 
 *** Target <nowiki>[Something the subject is looking for]</nowiki> 
 *** Non-target <nowiki>[Make sure to tag Expected if the Non-target is frequent] </nowiki> 
 *** Novel <nowiki>[Genuinely novel such as an event occurring once or so per experiment]</nowiki> 
 *** Expected <nowiki>[Of low information value, for example frequent Non-targets in an RSVP paradigm]</nowiki> 
-**** Standard 
-**** Distractor 
 *** Valid <nowiki>[Something that is understood to be valid such as an ID matches the person being displayed and it has all the  correct information]</nowiki> 
 *** Invalid <nowiki>[Something that is understood to not be valid such as like an ID with an impossible date-of-birth, or a photo not matching the person presenting it]</nowiki> 
 *** Congruence 
-**** Congruent <nowiki>[Like in Stroop paradigm when blue colored text displays the word blue] </nowiki> 
-**** Incongruent <nowiki> [Like in Stroop paradigm whena blue colored text reading displays the word red] </nowiki> 
-**** Temporal synchrony 
-***** Synchronous <nowiki>[When a mouse click sound happens right after clicking it]</nowiki> 
-***** Asynchronous <nowiki> [When a mouse click sound happens with significant delay which give could the person a strange feeling. Or if in a movie the sound of the explosion is heard before it appears visually.] </nowiki> 
 *** Feedback 
-**** Correct <nowiki>[Confirm something went well and last action was correct]</nowiki> 
-**** Incorrect  <nowiki>[Confirm something went wrong and last action was incorrect]</nowiki> 
-**** Non-informative <nowiki>[Feedback that provides no information in regards to correct, incorrect, etc.]</nowiki> 
-**** Expected <nowiki> [Feedback was expected as in a positive feedback after a response that was expected to be correct.]</nowiki> 
-**** Unexpected <nowiki>[Feedback was unexpected as when positive feedback was received when response was expected to be incorrect.]</nowiki> 
-**** On accuracy <nowiki>[Feedback was provided by evaluating response accuracy]</nowiki> 
-**** On reaction time <nowiki>[Feedback was provided by evaluating subject reaction time]</nowiki> 
-**** To self <nowiki>[Default]</nowiki> 
-**** To other <nowiki>[Observed feedback to another person such as in a social paradigm]</nowiki> 
-**** Deterministic <nowiki>[Feedback has a fixed relationship to what happened before]</nowiki> 
-**** Stochastic <nowiki>[Feedback is non-deterministic and does not have fixed relationship with what has happened before in the experiment]</nowiki> 
-**** False feedback <nowiki>[Feedback that was not honest for example as in feedback of correct on an incorrect response or vice versa]</nowiki> 
-***** Negative <nowiki> [Negative feedback was provided when it was not deserved]</nowiki> 
-***** Positive <nowiki>[Positive feedback was provided when it was not deserved]</nowiki> 
-*** Cue <nowiki>[An indicator of a future event, e.g. a sound cue that in 2-5 seconds a perturbation in driving will occur. Use (... Participant/Effect/Cognitive/Cue ~ [hed tags for the event to follow, or main aspect of the event to follow]) syntax.]</nowiki> 
-**** Constant delay <nowiki>[The cue is for an event that will happen after a constant delay.]</nowiki>
-***** # {takesValue, isNumeric, unitClass=time} <nowiki>[The delay, e.g. in seconds.]</nowiki>
-**** Variable delay <nowiki>[The cue is for an event that will happen after a variable delay.]</nowiki>
-***** # {takesValue} <nowiki>[The interval, e.g. between 2-5 seconds, of the variable delay.]</nowiki>
 ** Visual 
-*** Foveal 
-*** Peripheral     
-*** Perturbation <nowiki>[Sudden movement or perturbation of the virtual environment in a car driving or other scenario]</nowiki> 
 ** Auditory 
-*** Stereo 
-*** Mono 
-**** Left 
-**** Right 
 ** TMS 
-*** With SPGS <nowiki>[SPGS stands for spatial position guiding system]</nowiki> 
-*** Without SPGS <nowiki>[SPGS stands for spatial position guiding system]</nowiki> 
 ** Tactile 
-*** Vibration 
-*** Acupuncture 
-*** Eye puff 
-*** Swab <nowiki>[Mouth swab]</nowiki> 
 ** Vestibular 
-*** Shaking [being shaken or jerked around] 
 ** Pain 
-*** Heat 
-*** Cold 
-*** Pressure 
-*** Electric shock 
-*** Laser-evoked 
 ** Taste 
 ** Smell 
 ** Body part 
-*** Whole Body 
-*** Eye 
-*** Arm 
-**** Hand 
-***** Finger 
-****** Index 
-****** Thumb 
-****** Ring 
-****** Middle 
-****** Small <nowiki>[Pinkie or little finger]</nowiki> 
-*** Leg 
-**** Feet 
-***** Toes 
-*** Head 
-**** Face 
-***** Eyebrow 
-***** Lip 
-***** Forehead 
-***** Mouth 
-***** Nose 
-***** Chin 
-***** Cheek 
-*** Torso 
+
 * State <nowiki>{requireChild}</nowiki> 
 ** Level of consciousness <nowiki>{requireChild}</nowiki> 
 *** Awake 
 *** Drowsy 
 *** Sleep
-**** Stage <nowiki>{requireChild}</nowiki>
-***** <nowiki># {takesValue} [a number between 1 to 4, or 'REM']</nowiki>   
 *** Drunk 
 *** Anesthesia 
 *** Locked-in 
@@ -771,12 +371,6 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Sense of community <nowiki>[Primed to have an emotion such as patriotism]</nowiki> 
 *** <nowiki># {takesValue, isNumeric} [SCI stands for Sense of Community Index]</nowiki> 
 ** Sense of social justice 
-*** Distributive 
-*** Poverty  
-*** Inequality 
-*** Procedural 
-*** Interpersonal 
-*** Informational 
 ** Stress level <nowiki>{requireChild}</nowiki> 
 *** <nowiki>#  {takesValue, isNumeric} [A number between 0 and 1]</nowiki> 
 ** Task load <nowiki>{requireChild}</nowiki> 
@@ -790,21 +384,6 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Passive <nowiki>[There is a stimulus presentation but no behavioral measurements are collected from the subject. Subject is instructed not to make any behavioral outputs for example when told to carefully watch/listen/sense. The resting state is not considered passive.]</nowiki> 
 ** Resting <nowiki>[State when there is no stimulus presentation and no behavioral outputs]</nowiki> 
 ** Attention 
-*** Top-down <nowiki>[Instructed to pay attention to something explicitly]</nowiki> 
-*** Bottom-up <nowiki>[something captures your attention, like a big bang or your name]</nowiki> 
-**** Orienting <nowiki>[The lower state of the bottom-up  or the pre-bottom up state]</nowiki> 
-*** Covert  <nowiki>[Implicit]</nowiki> 
-*** Overt <nowiki>[Explicit]</nowiki> 
-*** Selective <nowiki>[If you have two circles but asked to pay attention to only one of them]</nowiki> 
-**** Divided <nowiki> [Attending to more than one object or location]</nowiki> 
-*** Focused <nowiki> [Paying a lot of attention]</nowiki> 
-*** Sustained <nowiki> [Paying attention for a continuous time]</nowiki> 
-*** To a location <nowiki> [Spatial -- use the location attribute to specify to where the attention is directed]</nowiki> 
-*** Arousal <nowiki>{requireChild}</nowiki> 
-*** Alerting <nowiki> [Keeping the arousal up in order to respond quickly]</nowiki> 
-*** Drowsy 
-*** Excited 
-*** Neutral 
 
 
 '''Experiment context''' <nowiki>{extensionAllowed} [Describes the context of the whole experiment or large portions of it and also includes tags that are common across all events]</nowiki> 
@@ -813,7 +392,6 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 * Standing 
 * Prone  <nowiki> [As in on a bed]</nowiki> 
 * Running 
-** Treadmill 
 * Walking 
 ** Treadmill 
 * Indoors <nowiki> [Default]</nowiki> 
@@ -821,17 +399,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Dim Room 
 * Outdoors 
 ** Terrain 
-*** Grass 
-*** Uneven 
-*** Boardwalk 
-*** Dirt 
-*** Leaves 
-*** Mud 
-*** Woodchip 
-*** Rocky 
-*** Gravel 
-*** Downhill 
-*** Uphill 
+
 * Motion platform <nowiki> [Subject is on a motion platform such as one that produces simulated car movements]</nowiki> 
 * Fixed screen 
 ** Distance <nowiki>[Assuming static subject]</nowiki> 
@@ -848,228 +416,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 '''HED'''  <nowiki> {requireChild} [Hierarchical Event Descriptor]</nowiki> 
 * <nowiki># {takesValue, isNumeric} [HED specification version number: normally there is no need to specify the version number in the HED string since it will be matched by default to the most recent compliant version, but this tag can be used to specify the exact HED version the HED string was based on.]</nowiki> 
 
-'''Paradigm''' <nowiki>{requireChild, extensionAllowed}[See Tasks in http://www.cognitiveatlas.org/tasks and CogPo definitions of paradigms]</nowiki>   
-* Action imitation task 
-* Action observation task 
-* Acupuncture task 
-* Adult attachment interview 
-* Alternating runs paradigm 
-* Animal naming task 
-* Antisaccade-prosaccade task 
-* Attention networks test 
-* Attentional blink task 
-* Audio-visual target-detection task 
-* Autism diagnostic observation schedule 
-* Ax-cpt task   
-* Backward digit span task 
-* Backward masking 
-* Balloon analogue risk task - BART
-* Behavioral investment allocation strategy - BIAS
-* Behavioral rating inventory of executive function 
-* Benton facial recognition test 
-* Birmingham object recognition battery 
-* Block design test 
-* Block tapping test 
-* Boston naming test 
-* Braille reading task 
-* Breath-holding 
-* Breathhold paradigm 
-* Brixton spatial anticipation test 
-* California verbal learning test 
-* California verbal learning test-ii 
-* Cambridge face memory test 
-* Cambridge gambling task 
-* Cambridge neuropsychological test automated battery 
-* Catbat task 
-* Category fluency test 
-* Cattell culture fair intelligence test 
-* Chewing-swallowing 
-* Chimeric animal stroop task 
-* Choice reaction time task 
-* Choice task between risky and non-risky options 
-* Classical conditioning 
-* Clinical evaluation of language fundamentals-3 
-* Color trails test 
-* Color-discrimination task 
-* Color-word stroop task 
-* Complex span test 
-* Conditional stop signal task 
-* Conditioning paradigm 
-** Behavioral conditioning paradigm 
-** Classical conditioning paradigm 
-* Continuous performance task 
-* Continuous recognition paradigm 
-* Counting stroop task 
-* Counting-calculation 
-* Cued explicit recognition 
-* Cups task 
-* Deception task 
-* Deductive reasoning paradigm 
-* Deductive reasoning task 
-* Delayed discounting task 
-* Delayed match to sample task 
-* Delayed nonmatch to sample task 
-* Delayed recall test 
-* Delayed response task 
-** Delayed matching to sample paradigm 
-*** Sternberg paradigm 
-* Devils task 
-* Dichotic listening task 
-* Digit cancellation task 
-* Digit span task 
-* Digit-symbol coding test 
-* Directed forgetting task 
-* Divided auditory attention 
-* Divided auditory attention paradigm 
-* Doors and people test 
-* Dot pattern expectancy task 
-* Drawing
-* Drawing paradigm 
-* Dual-task paradigm 
-* Early social communications scales 
-* Eating paradigm 
-* Eating-drinking 
-* Embedded figures test 
-* Emotional regulation task 
-* Encoding paradigm 
-* Encoding task 
-* Episodic recall 
-* Episodic recall paradigm 
-* Eriksen flanker task 
-* Extradimensional shift task 
-* Eye Saccade paradigm 
-** Anti saccade paradigm 
-** Simple saccade paradigm 
-* Face monitor-discrimination 
-* Face n-back task 
-* Fagerstrom test for nicotine dependence
-* Film viewing 
-* Finger tapping task 
-* Fixation task 
-* Flashing checkerboard 
-* Flexion-extension 
-* Forward digit span task 
-* Free word list recall 
-* Glasgow coma scale 
-* Go-no-go task 
-* Grasping task 
-* Gray oral reading test - 4
-* Haptic illusion task 
-* Hayling sentence completion test 
-* Heat sensitization-adaptation 
-* Heat stimulation 
-* Hooper visual organization test 
-* ID screening <nowiki> [Visual examination of multiple fields of an ID or document to detect invalid or suspicious fields. For example at a security checkpoint.]</nowiki>
-* Imagined emotion
-* Imagined movement 
-* Imagined objects-scenes
-* Instructed movement
-* Immediate recall test 
-* Inductive reasoning aptitude 
-* International affective picture system 
-* Intradimensional shift task 
-* Ishihara plates for color blindness 
-* Isometric force 
-* Item recognition paradigm 
-** Serial item recognition paradigm 
-* Item recognition task 
-* Kanizsa figures 
-* Keep-track task 
-* Letter comparison 
-* Letter fluency test 
-* Letter naming task 
-* Letter number sequencing 
-* Lexical decision task 
-* Listening span task 
-* Macauthur communicative development inventory
-* Machine failure detection task
-* Matching familiar figures test 
-* Matching pennies game 
-* Maudsley obsessive compulsive inventory 
-* Mechanical stimulation 
-* Memory span test 
-* Mental rotation task 
-* Micturition task 
-* Mini mental state examination
-* Mirror tracing test 
-* Mismatch negativity paradigm 
-* Mixed gambles task 
-* Modified erikson scale of communication attitudes 
-* Morris water maze 
-* Motor sequencing task 
-* Music comprehension-production 
-* N-back task 
-** Letter n-back task 
-* Naming 
-** Covert 
-** Overt 
-* Nine-hole peg test 
-* Non-choice task to study expected value and uncertainty 
-* Non-painful electrical stimulation 
-* Non-painful thermal stimulation 
-* Nonword repetition task 
-* Object alternation task 
-* Object-discrimination task 
-* Oculomotor delayed response 
-* Oddball discrimination paradigm 
-** Auditory oddball paradigm 
-** Visual oddball paradigm 
-*** Rapid serial visual presentation 
-* Oddball task 
-* Olfactory monitor-discrimination 
-* Operation span task 
-* Orthographic discrimination 
-* Paced auditory serial addition test 
-* Pain monitor-discrimination task 
-* Paired associate learning 
-* Paired associate recall 
-* Pantomime task 
-* Parrott scale 
-* Passive listening 
-* Passive viewing 
-* Pattern comparison 
-* Perturbed driving
-* Phonological discrimination 
-* Picture naming task 
-* Picture set test 
-* Picture-word stroop task 
-* Pitch monitor-discrimination 
-* Pointing 
-* Porteus maze test 
-* Positive and negative affect scale 
-* Posner cueing task 
-* Probabilistic classification task 
-* Probabilistic gambling task 
-* Probabilistic reversal learning 
-* Pseudoword naming task 
-* Psychomotor vigilance task
-* Pursuit rotor task 
-* Pyramids and palm trees task 
-* Rapid automatized naming test 
-* Rapid serial object transformation 
-* Reading - Covert
-* Reading - Overt
-* Reading paradigm 
-** Covert braille reading paradigm 
-** Covert visual reading paradigm 
-* Reading span task 
-* Recitation-repetition - Covert
-* Recitation-repetition - Overt
-* Remember-know task 
-* Response mapping task 
-* Rest
-** Rest eyes open
-** Rest eyes closed
-* Retrieval-induced forgetting task 
-* Reversal learning task 
-* Reward task 
-* Rey auditory verbal learning task 
-* Rey-ostereith complex figure test 
-* Reynell developmental language scales 
-* Rhyme verification task 
-* Risky gains task 
-* Rivermead behavioural memory test 
-* <nowiki>[extend here]</nowiki> 
+
 
 '''Unit classes''' 
 * acceleration <nowiki>{default=cm-per-s2}</nowiki> 

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -21,31 +21,29 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Experiment 
 *** Control <nowiki>{extensionAllowed} [Information about states and events of the software program that controls the experiment]</nowiki> 
 **** Activity <nowiki>[Experiment-specific actions such as moving a piece in a chess game. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the task.]</nowiki> 
+**** Initial context <nowiki>[Set the starting context for the experiment.]</nowiki> 
 **** Sequence<nowiki>[Used to designate that this event is part of a sequence of control events]</nowiki> 
-***** Experiment <nowiki>[Use Attribute/Onset and Attribute/Offset to indicate start and end of the experiment. Use Attribute/ID/Value/# to designate an identifier of the experiment.]</nowiki> 
-***** Block <nowiki>[Each block has the same general context and contains several trials -- use Attribute/Onset and Attribute/Offset to specify start and end.  Use Attribute/ID/Value/# to designate an identifier of the block.]</nowiki> 
-***** Trial <nowiki>[Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the trial.]</nowiki> 
-***** Pause <nowiki>[Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the pause.]</nowiki> 
-**** Task <nowiki>[Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the task.]</nowiki>  
-
-*** Initial context <nowiki>[Set the starting context for the experiment.]</nowiki> 
+***** Block <nowiki>[Each block has the same general context and contains several trials -- use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end.  Use Attribute/ID/Index/# to designate an identifier of the block.]</nowiki> 
+***** Experiment <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to indicate start and end of the experiment. Use Attribute/ID/Index/# to designate an identifier of the experiment.]</nowiki> 
+***** Pause <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the pause.]</nowiki> 
+***** Task <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the task.]</nowiki>  
+***** Trial <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the trial.]</nowiki> 
+**** Setup 
+**** Synchronization <nowiki>[An event used for synchronizing data streams]</nowiki> 
+***** Display refresh 
+***** Trigger 
+***** Status 
+***** Waiting for input 
+***** Loading 
+***** Error 
 *** Instruction <nowiki>[Give an instruction to the participant.]</nowiki> 
 *** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki> 
-*** Setup 
-*** Synchronization <nowiki>[An event used for synchronizing data streams]</nowiki> 
-**** Display refresh 
-**** Trigger 
-**** Status 
-**** Waiting for input 
-**** Loading 
-**** Error 
-
 *** Technical error <nowiki> {extensionAllowed} [Experimenters forgot to turn on something or the cord snagged and something may be wrong with the data.]</nowiki> 
 *** Informational <nowiki>{extensionAllowed} [Events that are only have informational value and cannot be put in other event categories.]</nowiki> 
 
 * Description <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=3}[Same as HED 1.0 description for human-readable text]</nowiki> 
 ** <nowiki># {takesValue}</nowiki> 
-* Label <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=0} [A label for the event that is less than 20 characters. For example /Label/Accept button. Please note that the information under this tag is primarily not for use in the analysis and is provided for the convenience in referring to events in the context of a single study. Please use Custom tag to define custom event hierarchies. Please do not mention the words Onset or Offset in the label. These should only be placed in Attribute/Onset  and Attribute/Offset.  Software automatically generates a final label with (onset) or (offset) in parentheses added to the original label. This makes it easier to automatically find onsets and offsets for the same event.]</nowiki> 
+* Label <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=0} [A label for the event that is less than 20 characters. For example /Label/Accept button. Please note that the information under this tag is primarily not for use in the analysis and is provided for the convenience in referring to events in the context of a single study. Please use Custom tag to define custom event hierarchies. Please do not mention the words Onset or Offset in the label. These should only be placed in Attribute/Temporal/Onset  and Attribute/Temporal/Offset.  Software automatically generates a final label with (onset) or (offset) in parentheses added to the original label. This makes it easier to automatically find onsets and offsets for the same event.]</nowiki> 
 ** <nowiki># {takesValue}</nowiki> 
 * Long name <nowiki>{requireChild, unique, predicateType=propertyOf, position=2} [A long name for the event that could be over 100 characters and could contain characters like vertical bars as separators. Long names are used for cases when one wants to encode a lot of information in a single string such as  Scenario | VehiclePassing | TravelLaneBLocked | Onset].</nowiki> 
 ** <nowiki># {takesValue}</nowiki> 
@@ -516,7 +514,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 * Instruction <nowiki> [This tag is placed in events of type Event/Category/Experimental stimulus/Instruction, grouped with one or more Action/ tags to replace the detailed specification XXX in Event/Category/Experimental stimulus/Instruction/XXX) in previous versions. Usage example:  Event/Category/Experimental stimulus/Instruction, (Action/Fixate, Attribute/Instruction) ]</nowiki>
 * Participant indication <nowiki> [This tag is placed in events of type Event/Category/Participant response and grouped with Participant/Effect/Cognitive/.. tags to specify the type of cognitive effect the participant has experienced. For example, in an RSVP paradigm, the subject can indicate the detection of a target with a button press. The HED string associated with this button press must include (Attribute/Participant indication, Participant/Effect/Cognitive/Target,...)]</nowiki>
 * Path <nowiki>{requireChild}</nowiki> 
-** Velocity  <nowiki>[Use Attribute/Onset or Attribute/Offset to specify onset or offset]</nowiki> 
+** Velocity  <nowiki>[Use Attribute/Temporal/Onset or Attribute/Temporal/Offset to specify onset or offset]</nowiki> 
 *** <nowiki># {takesValue, isNumeric, unitClass=speed} [Numeric value with default units of m-per-s]</nowiki> 
 ** Acceleration 
 *** <nowiki># {takesValue, isNumeric, unitClass=acceleration} [Numeric value with default units of m-per-s2] </nowiki> 
@@ -579,7 +577,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Depart 
 * Speech 
 * Hum 
-* Eye saccade <nowiki> [Use Attribute/Peak for the middle of saccade and Attribute/Onset for the start of a saccade]</nowiki> 
+* Eye saccade <nowiki> [Use Attribute/Peak for the middle of saccade and Attribute/Temporal/Onset for the start of a saccade]</nowiki> 
 * Eye fixation 
 * Eye blink
 ** Left base <nowiki>[The time of the first detectable eyelid movement on closing.]</nowiki>

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -19,6 +19,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Incidental {extensionAllowed} <nowiki>[An action such as a yawn or stretch not in response to a sensory presentation.]</nowiki>
 ** Data feature <nowiki>{extensionAllowed} [An event derived from the data itself, possibly inserted in a post-hoc fashion.]</nowiki>
 ** Experiment 
+**** Activity <nowiki>[Experiment-specific actions such as moving a piece in a chess game. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the task.]</nowiki> 
 *** Control <nowiki>{extensionAllowed} [Information about states and events of the software program that controls the experiment]</nowiki> 
 **** Sequence<nowiki>[Used to designate that this event is part of a sequence of control events]</nowiki> 
 ***** Experiment <nowiki>[Use Attribute/Onset and Attribute/Offset to indicate start and end of the experiment. Use Attribute/ID/Value/# to designate an identifier of the experiment.]</nowiki> 
@@ -26,10 +27,11 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ***** Trial <nowiki>[Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the trial.]</nowiki> 
 ***** Pause <nowiki>[Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the pause.]</nowiki> 
 **** Task <nowiki>[Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the task.]</nowiki>  
-**** Activity <nowiki>[Experiment-specific actions such as moving a piece in a chess game. Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the task.]</nowiki> 
+
 *** Initial context <nowiki>[Set the starting context for the experiment.]</nowiki> 
-*** Instruction 
+*** Instruction <nowiki>[Give an instruction to the participant.]</nowiki> 
 *** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki> 
+*** Setup 
 *** Synchronization <nowiki>[An event used for synchronizing data streams]</nowiki> 
 **** Display refresh 
 **** Trigger 
@@ -37,7 +39,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 **** Waiting for input 
 **** Loading 
 **** Error 
-*** Setup 
+
 *** Technical error <nowiki> {extensionAllowed} [Experimenters forgot to turn on something or the cord snagged and something may be wrong with the data.]</nowiki> 
 *** Informational <nowiki>{extensionAllowed} [Events that are only have informational value and cannot be put in other event categories.]</nowiki> 
 

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -13,23 +13,19 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Experimental <nowiki>{extensionAllowed} [Primary category for time-locked stimulus events.]</nowiki>
 *** Environmental <nowiki>{extensionAllowed}[An environmental event, for example, a change in experimental context such as walking on dirt versus sidewalk or a loud noise in the next room.]</nowiki> 
 
-** 
+
 
 ** Participant response <nowiki>{extensionAllowed} [The purpose of this event was to record the state or response of a participant. Note: participant actions may occur in other kinds of events, such as the experimenter records a terrain change as an event and the participant happens to be walking. In this case the event category would be Environmental. In contrast, if the participant started walking in response to an instruction or to some other stimulus, the event would be recorded as Participant response]</nowiki> 
-** Technical error <nowiki> {extensionAllowed} [Experimenters forgot to turn on something or the cord snagged and something may be wrong with the data]</nowiki> 
+
 ** Participant action <nowiki>[Any action engaged in by the participant.]</nowiki>
 *** Response <nowiki>[An action taken by a participant in response to an experimental or environmental stimulus.]</nowiki>
+*** Failure <nowiki>{extensionAllowed} [Situation in which participant acts outside of the constraints of the experiment -- such as driving outside the boundary of a simulation experiment or using equipment incorrectly]</nowiki> 
 *** Incidental <nowiki>[An action such as a yawn or stretch not in response to a sensory presentation.]</nowiki>
-** Participant failure <nowiki>{extensionAllowed} [Situation in which participant acts outside of the constraints of the experiment -- such as driving outside the boundary of a simulation experiment or using equipment incorrectly]</nowiki> 
+
 
 ** Data feature <nowiki>[An event derived from the data itself, possibly inserted in a post-hoc fashion.]</nowiki>
 
 ** Experiment 
-*** Initial context <nowiki>[Set the starting context for the experiment.]</nowiki> 
-*** Instruction 
-*** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki> 
-
-*** Informational <nowiki>{extensionAllowed} [Events that are only have informational value and cannot be put in other event categories.]</nowiki> 
 *** Control <nowiki>{extensionAllowed} [Information about states and events of the software program that controls the experiment]</nowiki> 
 **** Sequence<nowiki>[Used to designate that this event is part of a sequence of control events]</nowiki> 
 ***** Experiment <nowiki>[Use Attribute/Onset and Attribute/Offset to indicate start and end of the experiment. Use Attribute/ID/Value/# to designate an identifier of the experiment.]</nowiki> 
@@ -47,6 +43,13 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 **** Loading 
 **** Error 
 *** Setup 
+*** Initial context <nowiki>[Set the starting context for the experiment.]</nowiki> 
+*** Instruction 
+*** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki> 
+
+*** Technical error <nowiki> {extensionAllowed} [Experimenters forgot to turn on something or the cord snagged and something may be wrong with the data.]</nowiki> 
+*** Informational <nowiki>{extensionAllowed} [Events that are only have informational value and cannot be put in other event categories.]</nowiki> 
+
 
 * Description <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=3}[Same as HED 1.0 description for human-readable text]</nowiki> 
 ** <nowiki># {takesValue}</nowiki> 

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -19,8 +19,8 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Incidental {extensionAllowed} <nowiki>[An action such as a yawn or stretch not in response to a sensory presentation.]</nowiki>
 ** Data feature <nowiki>{extensionAllowed} [An event derived from the data itself, possibly inserted in a post-hoc fashion.]</nowiki>
 ** Experiment 
-**** Activity <nowiki>[Experiment-specific actions such as moving a piece in a chess game. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the task.]</nowiki> 
 *** Control <nowiki>{extensionAllowed} [Information about states and events of the software program that controls the experiment]</nowiki> 
+**** Activity <nowiki>[Experiment-specific actions such as moving a piece in a chess game. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the task.]</nowiki> 
 **** Sequence<nowiki>[Used to designate that this event is part of a sequence of control events]</nowiki> 
 ***** Experiment <nowiki>[Use Attribute/Onset and Attribute/Offset to indicate start and end of the experiment. Use Attribute/ID/Value/# to designate an identifier of the experiment.]</nowiki> 
 ***** Block <nowiki>[Each block has the same general context and contains several trials -- use Attribute/Onset and Attribute/Offset to specify start and end.  Use Attribute/ID/Value/# to designate an identifier of the block.]</nowiki> 

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -17,7 +17,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Incidental {extensionAllowed} <nowiki>[A non-task-related action taken by the participant -- for example yawning, standing up during a seated experiment, or responding to a loud noise unrelated to the experiment.]</nowiki>
 ** Data feature <nowiki>{extensionAllowed} [An event derived from the data itself, possibly inserted in a post-hoc fashion.]</nowiki>
 ** Experiment 
-*** Control <nowiki>{extensionAllowed} [Information about states and events that control the experiment.]</nowiki>
+*** Control <nowiki>{extensionAllowed} [An event pertaining to setup and/or control of the experiment.]</nowiki>
 **** Condition <nowiki>[An event used to indicate an experimental condition. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the condition.]</nowiki>
 **** Instruction <nowiki>[Give an instruction to the participant .]</nowiki>
 **** Pause <nowiki>[An event indicating a stop in recording. Use Attribute/Temporal/Onset and Attribute/Temporal/Duration to specify the length of the pause.]</nowiki>    

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -9,9 +9,9 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 
 '''Event''' 
 * Category <nowiki>{required, requireChild, position=1} [This is meant to designate the reason this event was recorded. Every event should have at least one category, but may have multiple categories.] </nowiki> 
-** Sensory presentation <nowiki>{extensionAllowed} [Something that can be perceived.]</nowiki>
+** Sensory presentation <nowiki> [Something that can be perceived.]</nowiki>
 *** Experimental <nowiki>{extensionAllowed} [Primary category for time-locked stimulus events.]</nowiki>
-*** Environmental <nowiki>{extensionAllowed}[An environmental event, for example, change in experimental context such as walking on dirt versus sidewalk]</nowiki> 
+*** Environmental <nowiki>{extensionAllowed}[An environmental event, for example, a change in experimental context such as walking on dirt versus sidewalk or a loud noise in the next room.]</nowiki> 
 
 ** Initial context <nowiki>[The purpose is to set the starting context for the experiment --- and if there is no initial context event---this information would be stored as a dataset tag]</nowiki> 
 ** Participant response <nowiki>{extensionAllowed} [The purpose of this event was to record the state or response of a participant. Note: participant actions may occur in other kinds of events, such as the experimenter records a terrain change as an event and the participant happens to be walking. In this case the event category would be Environmental. In contrast, if the participant started walking in response to an instruction or to some other stimulus, the event would be recorded as Participant response]</nowiki> 

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -21,7 +21,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 **** Condition <nowiki>[An event used to indicate an experimental condition. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the condition.]</nowiki>
 **** Instruction <nowiki>[Give an instruction to the participant .]</nowiki>
 **** Pause <nowiki>[An event indicating a stop in recording. Use Attribute/Temporal/Onset and Attribute/Temporal/Duration to specify the length of the pause.]</nowiki>    
-**** Procedure <nowiki>{extensionAllowed} [An event marking an experimental procedure, for example doing a saliva swab on the person, during the experiment. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the condition.]</nowiki>  
+**** Procedure <nowiki>[An event marking an experimental procedure, for example doing a saliva swab on the person, during the experiment. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the condition.]</nowiki>  
 **** Sync <nowiki>[An event used for synchronizing data streams.]</nowiki>
 *** Lab note <nowiki>{extensionAllowed} [Events that only have informational value and cannot be put in other event categories.]</nowiki> 
 *** Technical error <nowiki> {extensionAllowed} [Experimenters forgot to turn on something or the cord snagged and something may be wrong with the data.]</nowiki> 

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -14,16 +14,16 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Environmental <nowiki>{extensionAllowed}[An environmental event, for example, a change in experimental context such as walking on dirt versus sidewalk or a loud noise in the next room.]</nowiki> 
 ** Participant action <nowiki>[Any action engaged in by the participant.]</nowiki>
 *** Task-related {extensionAllowed} <nowiki>[An action taken by a participant in response to an experimental event.]</nowiki>
-*** Incidental {extensionAllowed} <nowiki>[A non-task related action taken by the participant -- for example yawning, standing up during a seated experiment, or responding to a loud noise unrelated to the experiment.]</nowiki>
+*** Incidental {extensionAllowed} <nowiki>[A non-task-related action taken by the participant -- for example yawning, standing up during a seated experiment, or responding to a loud noise unrelated to the experiment.]</nowiki>
 ** Data feature <nowiki>{extensionAllowed} [An event derived from the data itself, possibly inserted in a post-hoc fashion.]</nowiki>
 ** Experiment 
 *** Control <nowiki>{extensionAllowed} [Information about states and events that control the experiment.]</nowiki>
 **** Condition <nowiki>[An event used to indicate an experimental condition. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the condition.]</nowiki>
 **** Instruction <nowiki>[Give an instruction to the participant .]</nowiki>
 **** Pause <nowiki>[An event indicating a stop in recording. Use Attribute/Temporal/Onset and Attribute/Temporal/Duration to specify the length of the pause.]</nowiki>    
-**** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki>  
-**** Sync <nowiki>[An event used for synchronizing data streams]</nowiki>
-*** Lab note <nowiki>{extensionAllowed} [Events that are only have informational value and cannot be put in other event categories.]</nowiki> 
+**** Procedure <nowiki>{extensionAllowed} [An event marking an experimental procedure, for example doing a saliva swab on the person, during the experiment. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the condition.]</nowiki>  
+**** Sync <nowiki>[An event used for synchronizing data streams.]</nowiki>
+*** Lab note <nowiki>{extensionAllowed} [Events that only have informational value and cannot be put in other event categories.]</nowiki> 
 *** Technical error <nowiki> {extensionAllowed} [Experimenters forgot to turn on something or the cord snagged and something may be wrong with the data.]</nowiki> 
 * Description <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=3}[Same as HED 1.0 description for human-readable text]</nowiki> 
 ** <nowiki># {takesValue}</nowiki> 

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -1,4 +1,4 @@
-HED version: v1.3.0-restruct
+HED version: v1.4.0-restruct
 
 '''Syntax'''  
 
@@ -9,35 +9,41 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 
 '''Event''' 
 * Category <nowiki>{required, requireChild, position=1} [This is meant to designate the reason this event was recorded. Every event should have at least one category, but may have multiple categories.] </nowiki> 
+** Sensory presentation <nowiki>{extensionAllowed} [Something that can be perceived.]</nowiki>
+*** Experimental <nowiki>{extensionAllowed} [Primary category for time-locked stimulus events.]</nowiki>
+*** Environmental <nowiki>{extensionAllowed}[An environmental event, for example, change in experimental context such as walking on dirt versus sidewalk]</nowiki> 
+
 ** Initial context <nowiki>[The purpose is to set the starting context for the experiment --- and if there is no initial context event---this information would be stored as a dataset tag]</nowiki> 
 ** Participant response <nowiki>{extensionAllowed} [The purpose of this event was to record the state or response of a participant. Note: participant actions may occur in other kinds of events, such as the experimenter records a terrain change as an event and the participant happens to be walking. In this case the event category would be Environmental. In contrast, if the participant started walking in response to an instruction or to some other stimulus, the event would be recorded as Participant response]</nowiki> 
 ** Technical error <nowiki> {extensionAllowed} [Experimenters forgot to turn on something or the cord snagged and something may be wrong with the data]</nowiki> 
+** Participant action <nowiki>[Any action engaged in by the participant.]</nowiki>
+*** Response <nowiki>[An action taken by a participant in response to an experimental or environmental stimulus.]</nowiki>
+*** Incidental <nowiki>[An action such as a yawn or stretch not in response to a sensory presentation.]</nowiki>
 ** Participant failure <nowiki>{extensionAllowed} [Situation in which participant acts outside of the constraints of the experiment -- such as driving outside the boundary of a simulation experiment or using equipment incorrectly]</nowiki> 
-** Environmental <nowiki>{extensionAllowed}[Change in experimental context such as walking on dirt versus sidewalk]</nowiki> 
-** Experimental stimulus <nowiki>{extensionAllowed} [Primary category for time-locked stimulus events.]</nowiki>
-*** Instruction 
-** Experimental procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki> 
-** Incidental <nowiki>{extensionAllowed} [Not a part of the task as perceived by/instructed to the participant --- for example an airplane flew by and made noise or a random person showed up on the street]</nowiki> 
-** Miscellaneous <nowiki>{extensionAllowed} [Events that are only have informational value and cannot be put in other event categories.]</nowiki> 
-** Experiment control <nowiki>{extensionAllowed} [Information about states and events of the software program that controls the experiment]</nowiki> 
-*** Sequence<nowiki>[Used to designate that this event is part of a sequence of control events]</nowiki> 
-**** Experiment <nowiki>[Use Attribute/Onset and Attribute/Offset to indicate start and end of the experiment. Use Attribute/ID/Value/# to designate an identifier of the experiment.]</nowiki> 
-**** Block <nowiki>[Each block has the same general context and contains several trials -- use Attribute/Onset and Attribute/Offset to specify start and end.  Use Attribute/ID/Value/# to designate an identifier of the block.]</nowiki> 
-**** Trial <nowiki>[Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the trial.]</nowiki> 
-**** Pause <nowiki>[Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the pause.]</nowiki> 
-*** Task <nowiki>[Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the task.]</nowiki>  
-*** Activity <nowiki>[Experiment-specific actions such as moving a piece in a chess game. Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the task.]</nowiki> 
-**** Participant action
+
+
+** Instruction 
+** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki> 
+
+*** Informational <nowiki>{extensionAllowed} [Events that are only have informational value and cannot be put in other event categories.]</nowiki> 
+*** Control <nowiki>{extensionAllowed} [Information about states and events of the software program that controls the experiment]</nowiki> 
+**** Sequence<nowiki>[Used to designate that this event is part of a sequence of control events]</nowiki> 
+***** Experiment <nowiki>[Use Attribute/Onset and Attribute/Offset to indicate start and end of the experiment. Use Attribute/ID/Value/# to designate an identifier of the experiment.]</nowiki> 
+***** Block <nowiki>[Each block has the same general context and contains several trials -- use Attribute/Onset and Attribute/Offset to specify start and end.  Use Attribute/ID/Value/# to designate an identifier of the block.]</nowiki> 
+***** Trial <nowiki>[Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the trial.]</nowiki> 
+***** Pause <nowiki>[Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the pause.]</nowiki> 
+**** Task <nowiki>[Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the task.]</nowiki>  
+**** Activity <nowiki>[Experiment-specific actions such as moving a piece in a chess game. Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the task.]</nowiki> 
+***** Participant action
 *** Synchronization <nowiki>[An event used for synchronizing data streams]</nowiki> 
 **** Display refresh 
 **** Trigger 
-*** Status 
+**** Status 
 **** Waiting for input 
 **** Loading 
 **** Error 
 *** Setup 
-**** Parameters <nowiki>{predicateType=propertyOf}</nowiki> 
-***** <nowiki># {takesValue} [Experiment parameters in some a string. Do not used quotes.]</nowiki> 
+
 * Description <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=3}[Same as HED 1.0 description for human-readable text]</nowiki> 
 ** <nowiki># {takesValue}</nowiki> 
 * Label <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=0} [A label for the event that is less than 20 characters. For example /Label/Accept button. Please note that the information under this tag is primarily not for use in the analysis and is provided for the convenience in referring to events in the context of a single study. Please use Custom tag to define custom event hierarchies. Please do not mention the words Onset or Offset in the label. These should only be placed in Attribute/Onset  and Attribute/Offset.  Software automatically generates a final label with (onset) or (offset) in parentheses added to the original label. This makes it easier to automatically find onsets and offsets for the same event.]</nowiki> 
@@ -221,6 +227,8 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** # <nowiki>{takesValue}</nowiki>
 ** Synchronization <nowiki>[ID is used to tag an event for synchronizing data streams.]</nowiki>
 *** # <nowiki>{takesValue}</nowiki>
+* Parameters <nowiki>{predicateType=propertyOf}</nowiki> 
+**<nowiki># {takesValue} [Experiment parameters in some a string. Do not used quotes.]</nowiki> 
 * Sensory presentation <nowiki>{requireChild}[Object manifestation]</nowiki>
 ** Auditory
 ** Olfactory

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -13,6 +13,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Experimental <nowiki>{extensionAllowed} [Primary category for time-locked stimulus events.]</nowiki>
 *** Environmental <nowiki>{extensionAllowed}[An environmental event, for example, a change in experimental context such as walking on dirt versus sidewalk or a loud noise in the next room.]</nowiki> 
 
+** 
 ** Initial context <nowiki>[The purpose is to set the starting context for the experiment --- and if there is no initial context event---this information would be stored as a dataset tag]</nowiki> 
 ** Participant response <nowiki>{extensionAllowed} [The purpose of this event was to record the state or response of a participant. Note: participant actions may occur in other kinds of events, such as the experimenter records a terrain change as an event and the participant happens to be walking. In this case the event category would be Environmental. In contrast, if the participant started walking in response to an instruction or to some other stimulus, the event would be recorded as Participant response]</nowiki> 
 ** Technical error <nowiki> {extensionAllowed} [Experimenters forgot to turn on something or the cord snagged and something may be wrong with the data]</nowiki> 
@@ -21,9 +22,11 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Incidental <nowiki>[An action such as a yawn or stretch not in response to a sensory presentation.]</nowiki>
 ** Participant failure <nowiki>{extensionAllowed} [Situation in which participant acts outside of the constraints of the experiment -- such as driving outside the boundary of a simulation experiment or using equipment incorrectly]</nowiki> 
 
+** Data feature <nowiki>[An event derived from the data itself, possibly inserted in a post-hoc fashion.]</nowiki>
 
-** Instruction 
-** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki> 
+** Experiment 
+*** Instruction 
+*** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki> 
 
 *** Informational <nowiki>{extensionAllowed} [Events that are only have informational value and cannot be put in other event categories.]</nowiki> 
 *** Control <nowiki>{extensionAllowed} [Information about states and events of the software program that controls the experiment]</nowiki> 

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -1,4 +1,4 @@
-HED version: v1.4.0-restruct
+HED version: v1.5.0-restruct
 
 '''Syntax'''  
 

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -14,7 +14,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Environmental <nowiki>{extensionAllowed}[An environmental event, for example, a change in experimental context such as walking on dirt versus sidewalk or a loud noise in the next room.]</nowiki> 
 
 ** 
-** Initial context <nowiki>[The purpose is to set the starting context for the experiment --- and if there is no initial context event---this information would be stored as a dataset tag]</nowiki> 
+
 ** Participant response <nowiki>{extensionAllowed} [The purpose of this event was to record the state or response of a participant. Note: participant actions may occur in other kinds of events, such as the experimenter records a terrain change as an event and the participant happens to be walking. In this case the event category would be Environmental. In contrast, if the participant started walking in response to an instruction or to some other stimulus, the event would be recorded as Participant response]</nowiki> 
 ** Technical error <nowiki> {extensionAllowed} [Experimenters forgot to turn on something or the cord snagged and something may be wrong with the data]</nowiki> 
 ** Participant action <nowiki>[Any action engaged in by the participant.]</nowiki>
@@ -25,6 +25,7 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Data feature <nowiki>[An event derived from the data itself, possibly inserted in a post-hoc fashion.]</nowiki>
 
 ** Experiment 
+*** Initial context <nowiki>[Set the starting context for the experiment.]</nowiki> 
 *** Instruction 
 *** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki> 
 

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -12,35 +12,19 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ** Sensory presentation <nowiki> [Something that can be perceived.]</nowiki>
 *** Experimental <nowiki>{extensionAllowed} [Primary category for time-locked stimulus events.]</nowiki>
 *** Environmental <nowiki>{extensionAllowed}[An environmental event, for example, a change in experimental context such as walking on dirt versus sidewalk or a loud noise in the next room.]</nowiki> 
-
 ** Participant action <nowiki>[Any action engaged in by the participant.]</nowiki>
-*** Response {extensionAllowed} <nowiki>[An action taken by a participant in response to an experimental or environmental stimulus.]</nowiki>
-*** Failure {extensionAllowed} <nowiki>{extensionAllowed} [Situation in which participant acts outside of the constraints of the experiment -- such as driving outside the boundary of a simulation experiment or using equipment incorrectly]</nowiki> 
-*** Incidental {extensionAllowed} <nowiki>[An action such as a yawn or stretch not in response to a sensory presentation.]</nowiki>
+*** Task-related {extensionAllowed} <nowiki>[An action taken by a participant in response to an experimental event.]</nowiki>
+*** Incidental {extensionAllowed} <nowiki>[A non-task related action taken by the participant -- for example yawning, standing up during a seated experiment, or responding to a loud noise unrelated to the experiment.]</nowiki>
 ** Data feature <nowiki>{extensionAllowed} [An event derived from the data itself, possibly inserted in a post-hoc fashion.]</nowiki>
 ** Experiment 
-*** Control <nowiki>{extensionAllowed} [Information about states and events of the software program that controls the experiment]</nowiki> 
-**** Activity <nowiki>[Experiment-specific actions such as moving a piece in a chess game. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the task.]</nowiki> 
-**** Initial context <nowiki>[Set the starting context for the experiment.]</nowiki> 
-**** Sequence<nowiki>[Used to designate that this event is part of a sequence of control events]</nowiki> 
-***** Block <nowiki>[Each block has the same general context and contains several trials -- use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end.  Use Attribute/ID/Index/# to designate an identifier of the block.]</nowiki> 
-***** Experiment <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to indicate start and end of the experiment. Use Attribute/ID/Index/# to designate an identifier of the experiment.]</nowiki> 
-***** Pause <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the pause.]</nowiki> 
-***** Task <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the task.]</nowiki>  
-***** Trial <nowiki>[Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the trial.]</nowiki> 
-**** Setup 
-**** Synchronization <nowiki>[An event used for synchronizing data streams]</nowiki> 
-***** Display refresh 
-***** Trigger 
-***** Status 
-***** Waiting for input 
-***** Loading 
-***** Error 
-*** Instruction <nowiki>[Give an instruction to the participant.]</nowiki> 
-*** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki> 
+*** Control <nowiki>{extensionAllowed} [Information about states and events that control the experiment.]</nowiki>
+**** Condition <nowiki>[An event used to indicate an experimental condition. Use Attribute/Temporal/Onset and Attribute/Temporal/Offset to specify start and end. Use Attribute/ID/Index/# to designate an identifier of the condition.]</nowiki>
+**** Instruction <nowiki>[Give an instruction to the participant .]</nowiki>
+**** Pause <nowiki>[An event indicating a stop in recording. Use Attribute/Temporal/Onset and Attribute/Temporal/Duration to specify the length of the pause.]</nowiki>    
+**** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki>  
+**** Sync <nowiki>[An event used for synchronizing data streams]</nowiki>
+*** Lab note <nowiki>{extensionAllowed} [Events that are only have informational value and cannot be put in other event categories.]</nowiki> 
 *** Technical error <nowiki> {extensionAllowed} [Experimenters forgot to turn on something or the cord snagged and something may be wrong with the data.]</nowiki> 
-*** Informational <nowiki>{extensionAllowed} [Events that are only have informational value and cannot be put in other event categories.]</nowiki> 
-
 * Description <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=3}[Same as HED 1.0 description for human-readable text]</nowiki> 
 ** <nowiki># {takesValue}</nowiki> 
 * Label <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=0} [A label for the event that is less than 20 characters. For example /Label/Accept button. Please note that the information under this tag is primarily not for use in the analysis and is provided for the convenience in referring to events in the context of a single study. Please use Custom tag to define custom event hierarchies. Please do not mention the words Onset or Offset in the label. These should only be placed in Attribute/Temporal/Onset  and Attribute/Temporal/Offset.  Software automatically generates a final label with (onset) or (offset) in parentheses added to the original label. This makes it easier to automatically find onsets and offsets for the same event.]</nowiki> 

--- a/HED-schema.mediawiki
+++ b/HED-schema.mediawiki
@@ -13,18 +13,11 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 *** Experimental <nowiki>{extensionAllowed} [Primary category for time-locked stimulus events.]</nowiki>
 *** Environmental <nowiki>{extensionAllowed}[An environmental event, for example, a change in experimental context such as walking on dirt versus sidewalk or a loud noise in the next room.]</nowiki> 
 
-
-
-** Participant response <nowiki>{extensionAllowed} [The purpose of this event was to record the state or response of a participant. Note: participant actions may occur in other kinds of events, such as the experimenter records a terrain change as an event and the participant happens to be walking. In this case the event category would be Environmental. In contrast, if the participant started walking in response to an instruction or to some other stimulus, the event would be recorded as Participant response]</nowiki> 
-
 ** Participant action <nowiki>[Any action engaged in by the participant.]</nowiki>
-*** Response <nowiki>[An action taken by a participant in response to an experimental or environmental stimulus.]</nowiki>
-*** Failure <nowiki>{extensionAllowed} [Situation in which participant acts outside of the constraints of the experiment -- such as driving outside the boundary of a simulation experiment or using equipment incorrectly]</nowiki> 
-*** Incidental <nowiki>[An action such as a yawn or stretch not in response to a sensory presentation.]</nowiki>
-
-
-** Data feature <nowiki>[An event derived from the data itself, possibly inserted in a post-hoc fashion.]</nowiki>
-
+*** Response {extensionAllowed} <nowiki>[An action taken by a participant in response to an experimental or environmental stimulus.]</nowiki>
+*** Failure {extensionAllowed} <nowiki>{extensionAllowed} [Situation in which participant acts outside of the constraints of the experiment -- such as driving outside the boundary of a simulation experiment or using equipment incorrectly]</nowiki> 
+*** Incidental {extensionAllowed} <nowiki>[An action such as a yawn or stretch not in response to a sensory presentation.]</nowiki>
+** Data feature <nowiki>{extensionAllowed} [An event derived from the data itself, possibly inserted in a post-hoc fashion.]</nowiki>
 ** Experiment 
 *** Control <nowiki>{extensionAllowed} [Information about states and events of the software program that controls the experiment]</nowiki> 
 **** Sequence<nowiki>[Used to designate that this event is part of a sequence of control events]</nowiki> 
@@ -34,7 +27,9 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 ***** Pause <nowiki>[Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the pause.]</nowiki> 
 **** Task <nowiki>[Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the task.]</nowiki>  
 **** Activity <nowiki>[Experiment-specific actions such as moving a piece in a chess game. Use Attribute/Onset and Attribute/Offset to specify start and end. Use Attribute/ID/Value/# to designate an identifier of the task.]</nowiki> 
-***** Participant action
+*** Initial context <nowiki>[Set the starting context for the experiment.]</nowiki> 
+*** Instruction 
+*** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki> 
 *** Synchronization <nowiki>[An event used for synchronizing data streams]</nowiki> 
 **** Display refresh 
 **** Trigger 
@@ -43,13 +38,8 @@ From version 2.2, HED adheres to http://semver.org/ versioning.
 **** Loading 
 **** Error 
 *** Setup 
-*** Initial context <nowiki>[Set the starting context for the experiment.]</nowiki> 
-*** Instruction 
-*** Procedure <nowiki>{extensionAllowed} [For example doing a saliva swab on the person]</nowiki> 
-
 *** Technical error <nowiki> {extensionAllowed} [Experimenters forgot to turn on something or the cord snagged and something may be wrong with the data.]</nowiki> 
 *** Informational <nowiki>{extensionAllowed} [Events that are only have informational value and cannot be put in other event categories.]</nowiki> 
-
 
 * Description <nowiki>{requireChild, required, unique, predicateType=propertyOf, position=3}[Same as HED 1.0 description for human-readable text]</nowiki> 
 ** <nowiki># {takesValue}</nowiki> 

--- a/HEDremap.tsv
+++ b/HEDremap.tsv
@@ -178,3 +178,32 @@ Action/Switch attention/Intermodal/To modality/Olfactory	(Action/Switch attentio
 /Item/IAPS	(Object/Item/Multimedia/Photograph, Attribute/ID/Collection/IAPS/#)
 /Item/IADS	(Object/Item/Multimedia/Sound clip, Attribute/ID/CollectionS/IADS/#)
 /Item/SAM	(Object/Item/Multimedia/Drawing Attribute/ID/Collection/SAM/#)
+
+
+Event/Category/Initial context	Event/Category/Experiment/Initial context
+Event/Category/Participant response	Event/Category/Participant action/Response
+Event/Category/Technical error	Event/Category/Experiment/Technical error
+Event/Category/Participant failure	Event/Category/Participant action/Failure
+Event/Category/Environmental	Event/Category/Sensory presentation/Environmental
+Event/Category/Experimental stimulus	Event/Category/Sensory presentation/Experimental
+Event/Category/Experimental procedure	Event/Category/Experiment/Procedure
+Event/Category/Incidental	Event/Category/Participant action/Incidental
+Event/Category/Miscellaneous	
+Event/Category/Experiment control	Event/Category/Experiment/Control/
+Event/Category/Experiment control/Sequence	Event/Category/Experiment/Control/Sequence
+Event/Category/Experiment control/Sequence/Experiment	Event/Category/Experiment/Control/Sequence/Experiment
+Event/Category/Experiment control/Sequence/Block	Event/Category/Experiment/Control/Sequence/Block
+Event/Category/Experiment control/Sequence/Trial	Event/Category/Experiment/Control/Sequence/Trial
+Event/Category/Experiment control/Sequence/Pause	Event/Category/Experiment/Control/Sequence/Pause
+Event/Category/Experiment control/Task	Event/Category/Experiment/Control/Sequence/Task
+Event/Category/Experiment control/Activity	Event/Category/Experiment/Control/Activity
+Event/Category/Experiment control/Synchronization	Event/Category/Experiment/Control/Synchronization
+Event/Category/Experiment control/Synchronization/Display reflesh	Event/Category/Experiment/Control/Synchronization/Display reflesh
+Event/Category/Experiment control/Synchronization/Trigger	Event/Category/Experiment/Control/Synchronization/Trigger
+Event/Category/Experiment control/Status	Event/Category/Experiment/Control/Status
+Event/Category/Experiment control/Status/Waiting for input	Event/Category/Experiment/Control/Status/Wiating for input
+Event/Category/Experiment control/Status/Loading	Event/Category/Experiment/Control/Status/Loading
+Event/Category/Experiment control/Status/Error	Event/Category/Experiment/Control/Status/Error
+Event/Category/Experiment control/Setup	Event/Category/Experiment/Control/Setup
+Event/Category/Experiment control/Setup/Parameters	(Event/Category/Experiment/Setup, Attribute/Parameters)
+Event/Category/Experiment control/Setup/Parameters/#	(Event/Category/Experiment/Setup, Attribute/Parameters/#)


### PR DESCRIPTION
This reorganizes Event as per discussion (please verify) in HED-schema.mediawiki. The HED-schema-reduced.mediawiki file shows a stripped down schema so that we can work on the top level categories. 