### PR TITLE
Updated 8.0.0-alpha.2 to specify boolProperty attribute for Schema at…

### DIFF
--- a/HED-generation3-schema-V8.0.0-alpha.2.mediawiki
+++ b/HED-generation3-schema-V8.0.0-alpha.2.mediawiki
@@ -1159,22 +1159,22 @@ HED version: 8.0.0-alpha.2
 
 
 * allowedCharacter <nowiki>[An attribute of unit classes schema value placeholders indicating a special character that is allowed in expressing the value of that placeholder.]</nowiki>
-* defaultUnits <nowiki>[Default units for a tag.]</nowiki> 
-* extensionAllowed <nowiki>[Users can add unlimited levels of child nodes under this tag.]</nowiki> 
-* isNumeric <nowiki>[The tag hashtag placeholder must be replaced by a numerical value.]</nowiki> 
+* defaultUnits <nowiki>[An attribute of unit classes specifying the default units for a tag.]</nowiki> 
+* extensionAllowed <nowiki>{boolProperty}[Users can add unlimited levels of child nodes under this tag.]</nowiki> 
+* isNumeric <nowiki>{boolProperty}[The tag hashtag placeholder must be replaced by a numerical value.]</nowiki> 
 * position <nowiki>[Used to specify the order of the required and recommended tags in canonical order for display. The position attribute value should be an integer and the order can start at 0 or 1. Required or recommended tags without this attribute or with negative position will be shown after the others in canonical ordering.]</nowiki> 
 * predicateType <nowiki> [One of propertyOf, subclassOf, passThrough -- used to facilitate mapping to OWL or RDF.]</nowiki>  
-* recommended  <nowiki>[A HED string tagging an event is recommended to include this tag.]</nowiki> 
+* recommended  <nowiki>{boolProperty}[A HED string tagging an event is recommended to include this tag.]</nowiki> 
 * relatedTag <nowiki>[Additional HED tags suggested to be used with this tag. This attribute is used by tagging tools.]</nowiki> 
-* requireChild  <nowiki>[One of its descendants must be chosen to tag an event.]</nowiki> 
-* required <nowiki>[Every HED string tagging an event should include this tag.]</nowiki>
-* SIUnit  <nowiki>[Designates the name of an SI unit so it can be modified by multiple and submultiple names. Note that some units such as byte are designated as SI units although they are not part of the standard.]</nowiki>
-* SIUnitModifier <nowiki>[SI unit modifier indicating a multiple or submultiple of a base unit.]</nowiki> 
-* SIUnitSymbolModifier <nowiki>[SI unit symbol modifier indicating a multiple or submultiple of a base unit symbol.]</nowiki>
+* requireChild  <nowiki>{boolProperty}[One of its descendants must be chosen to tag an event.]</nowiki> 
+* required <nowiki>{boolProperty}[Every HED string tagging an event should include this tag.]</nowiki>
+* SIUnit  <nowiki>{boolProperty}[Designates the name of an SI unit so it can be modified by multiple and submultiple names. Note that some units such as byte are designated as SI units although they are not part of the standard.]</nowiki>
+* SIUnitModifier <nowiki>{boolProperty}[SI unit modifier indicating a multiple or submultiple of a base unit.]</nowiki> 
+* SIUnitSymbolModifier <nowiki>{boolProperty}[SI unit symbol modifier indicating a multiple or submultiple of a base unit symbol.]</nowiki>
 * suggestedTag <nowiki>[Additional HED tags suggested to be used with this tag. This attribute is used by tagging tools.]</nowiki> 
-* takesValue <nowiki>[This tag will have a hashtag placeholder child in the schema which is expected to be replaced with a user-defined value.] </nowiki> 
-* unique <nowiki>[Only one of this tag or its descendants can be used within a single tag group or event.]</nowiki> 
-* unitSymbol <nowiki>[Abbreviation or symbol representing a type of unit. Unit symbols  represent both the singular and the plural and thus cannot be pluralized.]</nowiki> 
+* takesValue <nowiki>{boolProperty}[This tag will have a hashtag placeholder child in the schema which is expected to be replaced with a user-defined value.] </nowiki> 
+* unique <nowiki>{boolProperty}[Only one of this tag or its descendants can be used within a single tag group or event.]</nowiki> 
+* unitSymbol <nowiki>{boolProperty}[Abbreviation or symbol representing a type of unit. Unit symbols  represent both the singular and the plural and thus cannot be pluralized.]</nowiki> 
 
 !# end hed 
 


### PR DESCRIPTION
We are in the process of transitioning to a new format for the XML. In the process the transition versions got tangled. 

Now

HED8.0.0-alpha.1   is HED-3G in the old format

HED8.0.0-alpha.2 is HED-3G where we are starting the transition.  In this commit there is no corresponding .xml as the tools for converting aren't there yet.