### PR TITLE
Changed unitClassAttribute name to unitClassProperty in alpha.2

### DIFF
--- a/HED-generation3-schema-V8.0.0-alpha.2.mediawiki
+++ b/HED-generation3-schema-V8.0.0-alpha.2.mediawiki
@@ -1158,8 +1158,8 @@ HED version: 8.0.0-alpha.2
 '''Schema attributes'''
 
 
-* allowedCharacter <nowiki>{unitClassAttribute}[An attribute of unit classes schema value placeholders indicating a special character that is allowed in expressing the value of that placeholder.]</nowiki>
-* defaultUnits <nowiki>{unitClassAttribute}[An attribute of unit classes specifying the default units for a tag.]</nowiki> 
+* allowedCharacter <nowiki>{unitClassProperty}[An attribute of unit classes schema value placeholders indicating a special character that is allowed in expressing the value of that placeholder.]</nowiki>
+* defaultUnits <nowiki>{unitClassProperty}[An attribute of unit classes specifying the default units for a tag.]</nowiki> 
 * extensionAllowed <nowiki>{boolProperty}[Users can add unlimited levels of child nodes under this tag.]</nowiki> 
 * isNumeric <nowiki>{boolProperty}[The tag hashtag placeholder must be replaced by a numerical value.]</nowiki> 
 * position <nowiki>[Used to specify the order of the required and recommended tags in canonical order for display. The position attribute value should be an integer and the order can start at 0 or 1. Required or recommended tags without this attribute or with negative position will be shown after the others in canonical ordering.]</nowiki> 
@@ -1168,13 +1168,13 @@ HED version: 8.0.0-alpha.2
 * relatedTag <nowiki>[Additional HED tags suggested to be used with this tag. This attribute is used by tagging tools.]</nowiki> 
 * requireChild  <nowiki>{boolProperty}[One of its descendants must be chosen to tag an event.]</nowiki> 
 * required <nowiki>{boolProperty}[Every HED string tagging an event should include this tag.]</nowiki>
-* SIUnit  <nowiki>{boolProperty, unitClassAttribute}[Designates the name of an SI unit so it can be modified by multiple and submultiple names. Note that some units such as byte are designated as SI units although they are not part of the standard.]</nowiki>
-* SIUnitModifier <nowiki>{boolProperty, unitModifierAttribute}[SI unit modifier indicating a multiple or submultiple of a base unit.]</nowiki> 
-* SIUnitSymbolModifier <nowiki>{boolProperty, unitModifierAttribute}[SI unit symbol modifier indicating a multiple or submultiple of a base unit symbol.]</nowiki>
+* SIUnit  <nowiki>{boolProperty, unitClassProperty}[Designates the name of an SI unit so it can be modified by multiple and submultiple names. Note that some units such as byte are designated as SI units although they are not part of the standard.]</nowiki>
+* SIUnitModifier <nowiki>{boolProperty, unitModifierProperty}[SI unit modifier indicating a multiple or submultiple of a base unit.]</nowiki> 
+* SIUnitSymbolModifier <nowiki>{boolProperty, unitModifierProperty}[SI unit symbol modifier indicating a multiple or submultiple of a base unit symbol.]</nowiki>
 * suggestedTag <nowiki>[Additional HED tags suggested to be used with this tag. This attribute is used by tagging tools.]</nowiki> 
 * takesValue <nowiki>{boolProperty}[This tag will have a hashtag placeholder child in the schema which is expected to be replaced with a user-defined value.] </nowiki> 
 * unique <nowiki>{boolProperty}[Only one of this tag or its descendants can be used within a single tag group or event.]</nowiki> 
-* unitSymbol <nowiki>{boolProperty, unitClassAttribute}[Abbreviation or symbol representing a type of unit. Unit symbols  represent both the singular and the plural and thus cannot be pluralized.]</nowiki> 
+* unitSymbol <nowiki>{boolProperty, unitClassProperty}[Abbreviation or symbol representing a type of unit. Unit symbols  represent both the singular and the plural and thus cannot be pluralized.]</nowiki> 
 
 !# end hed 
 


### PR DESCRIPTION
This addition is to the mediawiki version 8.0.0-alpha.2 in order to help with XML conversion testing.