### PR TITLE
Corrected missing # child on Item-count

### DIFF
--- a/hedwiki/HED-generation3-schema-8.0.0.mediawiki
+++ b/hedwiki/HED-generation3-schema-8.0.0.mediawiki
@@ -585,6 +585,7 @@ This schema is the first official release that includes an xsd and requires unit
 **** Fraction <nowiki>[A numerical value betwee 0 and 1.]</nowiki>
 ***** <nowiki># {takesValue, valueClass=numericClass}</nowiki>
 **** Item-count <nowiki>[The integer count of something which is usually grouped with the entity it is counting. (Item-count/3, A) indicates that 3 of A have occurred up to this point.]</nowiki>
+***** <nowiki># {takesValue, valueClass=numericClass}</nowiki>  
 **** Item-interval <nowiki>[An integer indicating how many items or entities have passed since the last one of these. An item interval of 0 indicates the current item.]</nowiki>
 ***** <nowiki># {takesValue, valueClass=numericClass}</nowiki>      
 **** Percentage <nowiki>[A fraction or ratio with 100 understood as the denominator.]</nowiki> 

--- a/hedxml/HED8.0.0.xml
+++ b/hedxml/HED8.0.0.xml
@@ -2766,6 +2766,16 @@
                   <node>
                      <name>Item-count</name>
                      <description>The integer count of something which is usually grouped with the entity it is counting. (Item-count/3, A) indicates that 3 of A have occurred up to this point.</description>
+                     <node>
+                        <name>#</name>
+                        <attribute>
+                           <name>takesValue</name>
+                        </attribute>
+                        <attribute>
+                           <name>valueClass</name>
+                           <value>numericClass</value>
+                        </attribute>
+                     </node>
                   </node>
                   <node>
                      <name>Item-interval</name>


### PR DESCRIPTION
This was an omission which was just discovered. We have not updated the version number from 8.0.0 and will put additional source in the release record.