### PR TITLE
Fixed missing open parentheses in description of Performed-using (issue #455)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,9 +5,9 @@ Copyright (c) 2021, HED Contributors.
 =======================================================================
 
 Creative Commons Corporation (Creative Commons) is not a law firm and
-does not provide legal services or legal advice. Distribution of 
-Creative Commons public licenses does not create a lawyer-client or 
-other relationship. Creative Commons makes its licenses and related 
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
 information available on an "as-is" basis. Creative Commons gives no
 warranties regarding its licenses, any material licensed under their
 terms and conditions, or any related information. Creative Commons
@@ -23,34 +23,34 @@ and certain other rights specified in the public license below. The
 following considerations are for informational purposes only, are
 not exhaustive, and do not form part of our licenses.
 
-	Considerations for licensors: Our public licenses are intended 
-	for use by those authorized to give the public permission to 
-	use material in ways otherwise restricted by copyright and 
+	Considerations for licensors: Our public licenses are intended
+	for use by those authorized to give the public permission to
+	use material in ways otherwise restricted by copyright and
 	certain other rights. Our licenses are irrevocable. Licensors
-	should read and understand the terms and conditions of the 
+	should read and understand the terms and conditions of the
 	license they choose before applying it. Licensors should also
-	secure all rights necessary before applying our licenses so 
+	secure all rights necessary before applying our licenses so
 	that the public can reuse the material as expected. Licensors
-	should clearly mark any material not subject to the license. 
-	This includes other CC-licensed material, or material used 
-	under an exception or limitation to copyright. More 
+	should clearly mark any material not subject to the license.
+	This includes other CC-licensed material, or material used
+	under an exception or limitation to copyright. More
 	considerations for licensors:
 		wiki.creativecommons.org/Considerations_for_licensors
-	
-	Considerations for the public: By using one of our public 
-	licenses, a licensor grants the public permission to use the 
-	licensed material under specified terms and conditions. If 
+
+	Considerations for the public: By using one of our public
+	licenses, a licensor grants the public permission to use the
+	licensed material under specified terms and conditions. If
 	the licensor's permission is not necessary for any reason?for
-	example, because of any applicable exception or limitation 
-	to copyright?then that use is not regulated by the license. 
-	Our licenses grant only permissions under copyright and 
-	certain other rights that a licensor has authority to grant. 
-	Use of the licensed material may still be restricted for 
-	other reasons, including because others have copyright or 
-	other rights in the material. A licensor may make special 
-	requests, such as asking that all changes be marked or 
-	described. Although not required by our licenses, you are 
-	encouraged to respect those requests where reasonable. 
+	example, because of any applicable exception or limitation
+	to copyright?then that use is not regulated by the license.
+	Our licenses grant only permissions under copyright and
+	certain other rights that a licensor has authority to grant.
+	Use of the licensed material may still be restricted for
+	other reasons, including because others have copyright or
+	other rights in the material. A licensor may make special
+	requests, such as asking that all changes be marked or
+	described. Although not required by our licenses, you are
+	encouraged to respect those requests where reasonable.
 	More considerations for the public:
 		wiki.creativecommons.org/Considerations_for_licensors
 
@@ -61,217 +61,217 @@ Creative Commons Attribution 4.0 International Public License
 By exercising the Licensed Rights (defined below), You accept and agree
 to be bound by the terms and conditions of this Creative Commons
 Attribution 4.0 International Public License ("Public License"). To the
-extent this Public License may be interpreted as a contract, You are 
+extent this Public License may be interpreted as a contract, You are
 granted the Licensed Rights in consideration of Your acceptance of these
-terms and conditions, and the Licensor grants You such rights in 
+terms and conditions, and the Licensor grants You such rights in
 consideration of benefits the Licensor receives from making the Licensed
 Material available under these terms and conditions.
 
 Section 1 Definitions.
 
- a. Adapted Material means material subject to Copyright and Similar 
+ a. Adapted Material means material subject to Copyright and Similar
 	Rights that is derived from or based upon the Licensed Material and
-	in which the Licensed Material is translated, altered, arranged, 
+	in which the Licensed Material is translated, altered, arranged,
 	transformed, or otherwise modified in a manner requiring permission
-	under the Copyright and Similar Rights held by the Licensor. For 
+	under the Copyright and Similar Rights held by the Licensor. For
 	purposes of this Public License, where the Licensed Material is a
 	musical work, performance, or sound recording, Adapted Material is
-	always produced where the Licensed Material is synched in timed 
+	always produced where the Licensed Material is synched in timed
 	relation with a moving image.
-	
- b. Adapter's License means the license You apply to Your Copyright 
-	and Similar Rights in Your contributions to Adapted Material in 
+
+ b. Adapter's License means the license You apply to Your Copyright
+	and Similar Rights in Your contributions to Adapted Material in
 	accordance with the terms and conditions of this Public License.
-	
- c. Copyright and Similar Rights means copyright and/or similar 
+
+ c. Copyright and Similar Rights means copyright and/or similar
 	rights closely related to copyright including, without limitation,
 	performance, broadcast, sound recording, and Sui Generis Database
-	Rights, without regard to how the rights are labeled or 
-	categorized. For purposes of this Public License, the rights 
-	specified in Section 2(b)(1)-(2) are not Copyright and Similar 
+	Rights, without regard to how the rights are labeled or
+	categorized. For purposes of this Public License, the rights
+	specified in Section 2(b)(1)-(2) are not Copyright and Similar
 	Rights.
-	
- d. Effective Technological Measures means those measures that, 
+
+ d. Effective Technological Measures means those measures that,
 	in the absence of proper authority, may not be circumvented under
 	laws fulfilling obligations under Article 11 of the WIPO Copyright
 	Treaty adopted on December 20, 1996, and/or similar international
 	agreements.
-	
- e. Exceptions and Limitations means fair use, fair dealing, and/or 
-	any other exception or limitation to Copyright and Similar Rights 
+
+ e. Exceptions and Limitations means fair use, fair dealing, and/or
+	any other exception or limitation to Copyright and Similar Rights
 	that applies to Your use of the Licensed Material.
-	
- f. Licensed Material means the artistic or literary work, database, 
+
+ f. Licensed Material means the artistic or literary work, database,
 	or other material to which the Licensor applied this Public License.
-	
- g. Licensed Rights means the rights granted to You subject to the terms 
-	and conditions of this Public License, which are limited to all 
-	Copyright and Similar Rights that apply to Your use of the Licensed 
+
+ g. Licensed Rights means the rights granted to You subject to the terms
+	and conditions of this Public License, which are limited to all
+	Copyright and Similar Rights that apply to Your use of the Licensed
 	Material and that the Licensor has authority to license.
-	
- h. Licensor means the individual(s) or entity(ies) granting rights 
+
+ h. Licensor means the individual(s) or entity(ies) granting rights
 	under this Public License.
-	
- i. Share means to provide material to the public by any means or 
+
+ i. Share means to provide material to the public by any means or
 	process that requires permission under the Licensed Rights, such
 	as reproduction, public display, public performance, distribution,
 	dissemination, communication, or importation, and to make material
-	available to the public including in ways that members of the 
-	public may access the material from a place and at a time 
+	available to the public including in ways that members of the
+	public may access the material from a place and at a time
 	individually chosen by them.
-	
- j. Sui Generis Database Rights means rights other than copyright 
-	resulting from Directive 96/9/EC of the European Parliament and 
-	of the Council of 11 March 1996 on the legal protection of 
-	databases, as amended and/or succeeded, as well as other 
+
+ j. Sui Generis Database Rights means rights other than copyright
+	resulting from Directive 96/9/EC of the European Parliament and
+	of the Council of 11 March 1996 on the legal protection of
+	databases, as amended and/or succeeded, as well as other
 	essentially equivalent rights anywhere in the world.
-	
- k. You means the individual or entity exercising the Licensed 
-	Rights under this Public License. Your has a corresponding 
+
+ k. You means the individual or entity exercising the Licensed
+	Rights under this Public License. Your has a corresponding
 	meaning.
 
 Section 2 Scope.
 
  a. License grant.
 
-        1. Subject to the terms and conditions of this Public License, 
-		the Licensor hereby grants You a worldwide, royalty-free, 
-		non-sublicensable, non-exclusive, irrevocable license to 
+        1. Subject to the terms and conditions of this Public License,
+		the Licensor hereby grants You a worldwide, royalty-free,
+		non-sublicensable, non-exclusive, irrevocable license to
 		exercise the Licensed Rights in the Licensed Material to:
-		
-            A. reproduce and Share the Licensed Material, in whole 
+
+            A. reproduce and Share the Licensed Material, in whole
 			or in part; and
-			
+
             B. produce, reproduce, and Share Adapted Material.
-			
-        2. Exceptions and Limitations. For the avoidance of doubt, 
-		where Exceptions and Limitations apply to Your use, this 
-		Public License does not apply, and You do not need to 
+
+        2. Exceptions and Limitations. For the avoidance of doubt,
+		where Exceptions and Limitations apply to Your use, this
+		Public License does not apply, and You do not need to
 		comply with its terms and conditions.
-		
-        3. Term. The term of this Public License is specified in 
+
+        3. Term. The term of this Public License is specified in
 		Section 6(a).
-		
-        4. Media and formats; technical modifications allowed. 
-		The Licensor authorizes You to exercise the Licensed 
-		Rights in all media and formats whether now known or 
-		hereafter created, and to make technical modifications 
-		necessary to do so. The Licensor waives and/or agrees 
+
+        4. Media and formats; technical modifications allowed.
+		The Licensor authorizes You to exercise the Licensed
+		Rights in all media and formats whether now known or
+		hereafter created, and to make technical modifications
+		necessary to do so. The Licensor waives and/or agrees
 		not to assert any right or authority to forbid You from
 		making technical modifications necessary to exercise the
 		Licensed Rights, including technical modifications necessary
-		to circumvent Effective Technological Measures. For 
-		purposes of this Public License, simply making 
-		modifications authorized by this Section 2(a)(4) 
+		to circumvent Effective Technological Measures. For
+		purposes of this Public License, simply making
+		modifications authorized by this Section 2(a)(4)
 		never produces Adapted Material.
-		
+
         5. Downstream recipients.
-		
-            A. Offer from the Licensor ? Licensed Material. 
-			Every recipient of the Licensed Material 
-			automatically receives an offer from the 
-			Licensor to exercise the Licensed Rights 
+
+            A. Offer from the Licensor ? Licensed Material.
+			Every recipient of the Licensed Material
+			automatically receives an offer from the
+			Licensor to exercise the Licensed Rights
 			under the terms and conditions of this Public License.
-			
-            B. No downstream restrictions. You may not offer or 
+
+            B. No downstream restrictions. You may not offer or
 			impose any additional or different terms or conditions
 			on, or apply any Effective Technological Measures to,
-			the Licensed Material if doing so restricts exercise 
-			of the Licensed Rights by any recipient of the Licensed 
+			the Licensed Material if doing so restricts exercise
+			of the Licensed Rights by any recipient of the Licensed
 			Material.
-			
+
         6. No endorsement. Nothing in this Public License constitutes
 		or may be construed as permission to assert or imply that You
-		are, or that Your use of the Licensed Material is, connected 
-		with, or sponsored, endorsed, or granted official status by, 
-		the Licensor or others designated to receive attribution as 
+		are, or that Your use of the Licensed Material is, connected
+		with, or sponsored, endorsed, or granted official status by,
+		the Licensor or others designated to receive attribution as
 		provided in Section 3(a)(1)(A)(i).
 
  b. Other rights.
-  
-        1. Moral rights, such as the right of integrity, are not 
-		licensed under this Public License, nor are publicity, 
-		privacy, and/or other similar personality rights; however, 
-		to the extent possible, the Licensor waives and/or agrees 
-		not to assert any such rights held by the Licensor to the 
-		limited extent necessary to allow You to exercise the 
+
+        1. Moral rights, such as the right of integrity, are not
+		licensed under this Public License, nor are publicity,
+		privacy, and/or other similar personality rights; however,
+		to the extent possible, the Licensor waives and/or agrees
+		not to assert any such rights held by the Licensor to the
+		limited extent necessary to allow You to exercise the
 		Licensed Rights, but not otherwise.
-		
-        2. Patent and trademark rights are not licensed under 
+
+        2. Patent and trademark rights are not licensed under
 		this Public License.
-		
-        3. To the extent possible, the Licensor waives any right 
-		to collect royalties from You for the exercise of the 
+
+        3. To the extent possible, the Licensor waives any right
+		to collect royalties from You for the exercise of the
 		Licensed Rights, whether directly or through a collecting
-		society under any voluntary or waivable statutory or 
-		compulsory licensing scheme. In all other cases the 
-		Licensor expressly reserves any right to collect such 
+		society under any voluntary or waivable statutory or
+		compulsory licensing scheme. In all other cases the
+		Licensor expressly reserves any right to collect such
 		royalties.
 
 Section 3 License Conditions.
 
-Your exercise of the Licensed Rights is expressly made subject to 
+Your exercise of the Licensed Rights is expressly made subject to
 the following conditions.
 
  a. Attribution.
 
-        1. If You Share the Licensed Material (including in 
+        1. If You Share the Licensed Material (including in
 		modified form), You must:
-		
-            A. retain the following if it is supplied by the 
+
+            A. retain the following if it is supplied by the
 			Licensor with the Licensed Material:
                 i. identification of the creator(s) of the Licensed
-				Material and any others designated to receive 
-				attribution, in any reasonable manner requested 
+				Material and any others designated to receive
+				attribution, in any reasonable manner requested
 				by the Licensor (including by pseudonym if designated);
-				
+
                 ii. a copyright notice;
-				
+
                 iii. a notice that refers to this Public License;
-				
-                iv. a notice that refers to the disclaimer of 
+
+                iv. a notice that refers to the disclaimer of
 				warranties;
-				
-                v. a URI or hyperlink to the Licensed Material to 
+
+                v. a URI or hyperlink to the Licensed Material to
 				the extent reasonably practicable;
-				
-            B. indicate if You modified the Licensed Material and 
+
+            B. indicate if You modified the Licensed Material and
 			retain an indication of any previous modifications; and
-			
-            C. indicate the Licensed Material is licensed under 
-			this Public License, and include the text of, or the 
+
+            C. indicate the Licensed Material is licensed under
+			this Public License, and include the text of, or the
 			URI or hyperlink to, this Public License.
-			
-        2. You may satisfy the conditions in Section 3(a)(1) in 
-		any reasonable manner based on the medium, means, and 
-		context in which You Share the Licensed Material. For 
+
+        2. You may satisfy the conditions in Section 3(a)(1) in
+		any reasonable manner based on the medium, means, and
+		context in which You Share the Licensed Material. For
 		example, it may be reasonable to satisfy the conditions
-		by providing a URI or hyperlink to a resource that 
+		by providing a URI or hyperlink to a resource that
 		includes the required information.
-		
-        3. If requested by the Licensor, You must remove any 
-		of the information required by Section 3(a)(1)(A) to the 
+
+        3. If requested by the Licensor, You must remove any
+		of the information required by Section 3(a)(1)(A) to the
 		extent reasonably practicable.
-		
+
         4. If You Share Adapted Material You produce, the Adapter's
-		License You apply must not prevent recipients of the 
+		License You apply must not prevent recipients of the
 		Adapted Material from complying with this Public License.
 
 Section 4 Sui Generis Database Rights.
 
-Where the Licensed Rights include Sui Generis Database Rights that 
+Where the Licensed Rights include Sui Generis Database Rights that
 apply to Your use of the Licensed Material:
 
  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
-	to extract, reuse, reproduce, and Share all or a substantial 
+	to extract, reuse, reproduce, and Share all or a substantial
 	portion of the contents of the database;
- 
- b. if You include all or a substantial portion of the database 
-    contents in a database in which You have Sui Generis Database 
-	Rights, then the database in which You have Sui Generis Database 
+
+ b. if You include all or a substantial portion of the database
+    contents in a database in which You have Sui Generis Database
+	Rights, then the database in which You have Sui Generis Database
 	Rights (but not its individual contents) is Adapted Material; and
- 
- c. You must comply with the conditions in Section 3(a) if You Share 
+
+ c. You must comply with the conditions in Section 3(a) if You Share
     all or a substantial portion of the contents of the database.
 
 For the avoidance of doubt, this Section 4 supplements and does not
@@ -280,105 +280,105 @@ Rights include other Copyright and Similar Rights.
 
 Section 5 Disclaimer of Warranties and Limitation of Liability.
 
- a. Unless otherwise separately undertaken by the Licensor, to the 
-	extent possible, the Licensor offers the Licensed Material 
-	as-is and as-available, and makes no representations or 
-	warranties of any kind concerning the Licensed Material, 
-	whether express, implied, statutory, or other. This includes, 
-	without limitation, warranties of title, merchantability, 
-	fitness for a particular purpose, non-infringement, absence of 
-	latent or other defects, accuracy, or the presence or absence 
-	of errors, whether or not known or discoverable. Where 
-	disclaimers of warranties are not allowed in full or in part, 
+ a. Unless otherwise separately undertaken by the Licensor, to the
+	extent possible, the Licensor offers the Licensed Material
+	as-is and as-available, and makes no representations or
+	warranties of any kind concerning the Licensed Material,
+	whether express, implied, statutory, or other. This includes,
+	without limitation, warranties of title, merchantability,
+	fitness for a particular purpose, non-infringement, absence of
+	latent or other defects, accuracy, or the presence or absence
+	of errors, whether or not known or discoverable. Where
+	disclaimers of warranties are not allowed in full or in part,
 	this disclaimer may not apply to You.
-    
+
  b. To the extent possible, in no event will the Licensor be liable
-	to You on any legal theory (including, without limitation, 
-	negligence) or otherwise for any direct, special, indirect, 
-	incidental, consequential, punitive, exemplary, or other losses, 
-	costs, expenses, or damages arising out of this Public License 
-	or use of the Licensed Material, even if the Licensor has been 
-	advised of the possibility of such losses, costs, expenses, or 
-	damages. Where a limitation of liability is not allowed in full 
+	to You on any legal theory (including, without limitation,
+	negligence) or otherwise for any direct, special, indirect,
+	incidental, consequential, punitive, exemplary, or other losses,
+	costs, expenses, or damages arising out of this Public License
+	or use of the Licensed Material, even if the Licensor has been
+	advised of the possibility of such losses, costs, expenses, or
+	damages. Where a limitation of liability is not allowed in full
 	or in part, this limitation may not apply to You.
 
  c. The disclaimer of warranties and limitation of liability provided
-	above shall be interpreted in a manner that, to the extent 
-	possible, most closely approximates an absolute disclaimer and 
+	above shall be interpreted in a manner that, to the extent
+	possible, most closely approximates an absolute disclaimer and
 	waiver of all liability.
 
 Section 6 Term and Termination.
 
- a. This Public License applies for the term of the Copyright and 
-	Similar Rights licensed here. However, if You fail to comply with 
-	this Public License, then Your rights under this Public License 
+ a. This Public License applies for the term of the Copyright and
+	Similar Rights licensed here. However, if You fail to comply with
+	this Public License, then Your rights under this Public License
 	terminate automatically.
 
- b. Where Your right to use the Licensed Material has terminated 
+ b. Where Your right to use the Licensed Material has terminated
 	under Section 6(a), it reinstates:
-	
+
         1. automatically as of the date the violation is cured, provided
 		it is cured within 30 days of Your discovery of the violation; or
-		
+
         2. upon express reinstatement by the Licensor.
-		
+
     For the avoidance of doubt, this Section 6(b) does not affect any right
-	the Licensor may have to seek remedies for Your violations of this 
+	the Licensor may have to seek remedies for Your violations of this
 	Public License.
-	
- c. For the avoidance of doubt, the Licensor may also offer the Licensed 
-	Material under separate terms or conditions or stop distributing the 
-	Licensed Material at any time; however, doing so will not terminate 
+
+ c. For the avoidance of doubt, the Licensor may also offer the Licensed
+	Material under separate terms or conditions or stop distributing the
+	Licensed Material at any time; however, doing so will not terminate
 	this Public License.
-	
+
  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public License.
 
 Section 7 Other Terms and Conditions.
 
- a. The Licensor shall not be bound by any additional or different terms 
+ a. The Licensor shall not be bound by any additional or different terms
 	or conditions communicated by You unless expressly agreed.
-	
+
  b. Any arrangements, understandings, or agreements regarding the Licensed
-	Material not stated herein are separate from and independent of the 
+	Material not stated herein are separate from and independent of the
 	terms and conditions of this Public License.
 
 Section 8 Interpretation.
 
  a. For the avoidance of doubt, this Public License does not, and shall not
-	be interpreted to, reduce, limit, restrict, or impose conditions on any 
-	use of the Licensed Material that could lawfully be made without 
+	be interpreted to, reduce, limit, restrict, or impose conditions on any
+	use of the Licensed Material that could lawfully be made without
 	permission under this Public License.
-	
- b. To the extent possible, if any provision of this Public License is 
-	deemed unenforceable, it shall be automatically reformed to the 
-	minimum extent necessary to make it enforceable. If the provision 
-	cannot be reformed, it shall be severed from this Public License 
-	without affecting the enforceability of the remaining terms and 
+
+ b. To the extent possible, if any provision of this Public License is
+	deemed unenforceable, it shall be automatically reformed to the
+	minimum extent necessary to make it enforceable. If the provision
+	cannot be reformed, it shall be severed from this Public License
+	without affecting the enforceability of the remaining terms and
 	conditions.
-	
- c. No term or condition of this Public License will be waived and no 
-	failure to comply consented to unless expressly agreed to by the 
+
+ c. No term or condition of this Public License will be waived and no
+	failure to comply consented to unless expressly agreed to by the
 	Licensor.
-	
+
  d. Nothing in this Public License constitutes or may be interpreted as
-	a limitation upon, or waiver of, any privileges and immunities that 
-	apply to the Licensor or You, including from the legal processes of 
+	a limitation upon, or waiver of, any privileges and immunities that
+	apply to the Licensor or You, including from the legal processes of
 	any jurisdiction or authority.
 
-Creative Commons is not a party to its public licenses. Notwithstanding, 
-Creative Commons may elect to apply one of its public licenses to material 
-it publishes and in those instances will be considered the ?Licensor.? 
+Creative Commons is not a party to its public licenses. Notwithstanding,
+Creative Commons may elect to apply one of its public licenses to material
+it publishes and in those instances will be considered the ?Licensor.?
 The text of the Creative Commons public licenses is dedicated to the public
-domain under the CC0 Public Domain Dedication. Except for the limited 
-purpose of indicating that material is shared under a Creative Commons 
-public license or as otherwise permitted by the Creative Commons policies 
-published at creativecommons.org/policies, Creative Commons does not 
-authorize the use of the trademark ?Creative Commons? or any other 
-trademark or logo of Creative Commons without its prior written consent 
-including, without limitation, in connection with any unauthorized 
-modifications to any of its public licenses or any other arrangements, 
-understandings, or agreements concerning use of licensed material. 
-For the avoidance of doubt, this paragraph does not form part of the 
+domain under the CC0 Public Domain Dedication. Except for the limited
+purpose of indicating that material is shared under a Creative Commons
+public license or as otherwise permitted by the Creative Commons policies
+published at creativecommons.org/policies, Creative Commons does not
+authorize the use of the trademark ?Creative Commons? or any other
+trademark or logo of Creative Commons without its prior written consent
+including, without limitation, in connection with any unauthorized
+modifications to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material.
+For the avoidance of doubt, this paragraph does not form part of the
 public licenses.
 
 Creative Commons may be contacted at creativecommons.org.

--- a/prerelease/CHANGES.md
+++ b/prerelease/CHANGES.md
@@ -8,4 +8,5 @@ a BIDS or another standard specifies details.
 * Added `Relation/Spatial-relation/Left-center-of` and `Relation/Spatial-relation/Right-center-of`
 and updated the `relatedTags` of other spatial relationship tags.
 * Added a `deprecated` schema attribute to indicate that this tag should no longer be used.
-  This boolean attribute was added to provide a schema evolution path without removing any tags. 
+  This boolean attribute was added to provide a schema evolution path without removing any tags.
+* Corrected missing open parenthesis in description for `Relation/Connective-relation/Performed-using`.

--- a/prerelease/HED8.2.0.mediawiki
+++ b/prerelease/HED8.2.0.mediawiki
@@ -1095,7 +1095,7 @@ This schema includes an xsd and requires unit class, unit modifier, value class,
 ** Member-of <nowiki>[(A, (Member-of, B)) indicates A is a member of group B.]</nowiki>
 ** Part-of <nowiki>[(A, (Part-of, B)) indicates A is a part of the whole B.]</nowiki>
 ** Performed-by <nowiki>[(A, (Performed-by, B)) indicates that the action or procedure A was carried out by agent B.]</nowiki>
-** Performed-using <nowiki>[A, (Performed-using, B)) indicates that the action or procedure A was accomplished using B.]</nowiki>
+** Performed-using <nowiki>[(A, (Performed-using, B)) indicates that the action or procedure A was accomplished using B.]</nowiki>
 ** Related-to <nowiki>[(A, (Related-to, B)) indicates A has some relationship to B.]</nowiki>
 ** Unrelated-to <nowiki>[(A, (Unrelated-to, B)) indicates that A is not related to B.  For example, A is not related to Task.]</nowiki>
 * Directional-relation <nowiki>[A relationship indicating direction of change of one entity relative to another. The first entity is the focus.]</nowiki>

--- a/prerelease/HED8.2.0.xml
+++ b/prerelease/HED8.2.0.xml
@@ -2090,6 +2090,10 @@
                   </node>
                </node>
                <node>
+                  <name>Ethnicity</name>
+                  <description>Belong to a social group that has a common national or cultural tradition. Use with Label to avoid extension.</description>
+               </node>
+               <node>
                   <name>Handedness</name>
                   <description>Individual preference for use of a hand, known as the dominant hand.</description>
                   <node>
@@ -2104,6 +2108,10 @@
                      <name>Ambidextrous</name>
                      <description>Having no overall dominance in the use of right or left hand or foot in the performance of tasks that require one hand or foot.</description>
                   </node>
+               </node>
+               <node>
+                  <name>Race</name>
+                  <description>Belonging to a group sharing physical or social qualities as defined within a specified society. Use with Label to avoid extension.</description>
                </node>
             </node>
          </node>
@@ -5544,7 +5552,7 @@
          </attribute>
          <node>
             <name>Comparative-relation</name>
-            <description>Something considered in comparison to something else. The first argument is the focus.</description>
+            <description>Something considered in comparison to something else. The first entity is the focus.</description>
             <node>
                <name>Approximately-equal-to</name>
                <description>(A, (Approximately-equal-to, B)) indicates that A and B have almost the same value. Here A and B could refer to sizes, orders, positions or other quantities.</description>
@@ -5576,7 +5584,7 @@
          </node>
          <node>
             <name>Connective-relation</name>
-            <description>Indicates two items are related in some way.</description>
+            <description>Indicates two entities are related in some way. The first entity is the focus.</description>
             <node>
                <name>Belongs-to</name>
                <description>(A, (Belongs-to, B)) indicates that A is a member of B.</description>
@@ -5627,7 +5635,7 @@
             </node>
             <node>
                <name>Performed-using</name>
-               <description>A, (Performed-using, B)) indicates that the action or procedure A was accomplished using B.</description>
+               <description>(A, (Performed-using, B)) indicates that the action or procedure A was accomplished using B.</description>
             </node>
             <node>
                <name>Related-to</name>
@@ -5640,7 +5648,7 @@
          </node>
          <node>
             <name>Directional-relation</name>
-            <description>A relationship indicating direction of change.</description>
+            <description>A relationship indicating direction of change of one entity relative to another. The first entity is the focus.</description>
             <node>
                <name>Away-from</name>
                <description>(A, (Away-from, B)) indicates that A is going or has moved away from B. The meaning depends on A and B.</description>
@@ -5651,8 +5659,20 @@
             </node>
          </node>
          <node>
+            <name>Logical-relation</name>
+            <description>Indicating a logical relationship between entities. The first entity is usually the focus.</description>
+            <node>
+               <name>And</name>
+               <description>(A, (And, B)) means A and B are both in effect.</description>
+            </node>
+            <node>
+               <name>Or</name>
+               <description>(A, (Or, B)) means at least one of A and B are in effect.</description>
+            </node>
+         </node>
+         <node>
             <name>Spatial-relation</name>
-            <description>Indicating information about position.</description>
+            <description>Indicating a relationship about position between entities.</description>
             <node>
                <name>Above</name>
                <description>(A, (Above, B)) means A is in a place or position that is higher than B.</description>
@@ -5738,11 +5758,26 @@
                </attribute>
             </node>
             <node>
+               <name>Lower-center-of</name>
+               <description>(A, (Lower-center-of, B)) means A is situated on the lower center part of B (due south). This relation is often used to specify qualitative information about screen position.</description>
+               <attribute>
+                  <name>relatedTag</name>
+                  <value>Center-of</value>
+                  <value>Lower-left-of</value>
+                  <value>Lower-right-of</value>
+                  <value>Upper-center-of</value>
+                  <value>Upper-right-of</value>
+               </attribute>
+            </node>
+            <node>
                <name>Lower-left-of</name>
                <description>(A, (Lower-left-of, B)) means A is situated on the lower left part of B. This relation is often used to specify qualitative information about screen position.</description>
                <attribute>
                   <name>relatedTag</name>
+                  <value>Center-of</value>
+                  <value>Lower-center-of</value>
                   <value>Lower-right-of</value>
+                  <value>Upper-center-of</value>
                   <value>Upper-left-of</value>
                   <value>Upper-right-of</value>
                </attribute>
@@ -5752,7 +5787,11 @@
                <description>(A, (Lower-right-of, B)) means A is situated on the lower right part of B. This relation is often used to specify qualitative information about screen position.</description>
                <attribute>
                   <name>relatedTag</name>
+                  <value>Center-of</value>
+                  <value>Lower-center-of</value>
+                  <value>Lower-left-of</value>
                   <value>Upper-left-of</value>
+                  <value>Upper-center-of</value>
                   <value>Upper-left-of</value>
                   <value>Lower-right-of</value>
                </attribute>
@@ -5806,12 +5845,28 @@
                <description>(A, (Top-of, B)) means A is on the uppermost part, side, or surface of B.</description>
             </node>
             <node>
+               <name>Upper-center-of</name>
+               <description>(A, (Upper-center-of, B)) means A is situated on the upper center part of B (due north). This relation is often used to specify qualitative information about screen position.</description>
+               <attribute>
+                  <name>relatedTag</name>
+                  <value>Center-of</value>
+                  <value>Lower-center-of</value>
+                  <value>Lower-left-of</value>
+                  <value>Lower-right-of</value>
+                  <value>Upper-center-of</value>
+                  <value>Upper-right-of</value>
+               </attribute>
+            </node>
+            <node>
                <name>Upper-left-of</name>
                <description>(A, (Upper-left-of, B)) means A is situated on the upper left part of B. This relation is often used to specify qualitative information about screen position.</description>
                <attribute>
                   <name>relatedTag</name>
+                  <value>Center-of</value>
+                  <value>Lower-center-of</value>
                   <value>Lower-left-of</value>
                   <value>Lower-right-of</value>
+                  <value>Upper-center-of</value>
                   <value>Upper-right-of</value>
                </attribute>
             </node>
@@ -5820,8 +5875,11 @@
                <description>(A, (Upper-right-of, B)) means A is situated on the upper right part of B. This relation is often used to specify qualitative information about screen position.</description>
                <attribute>
                   <name>relatedTag</name>
+                  <value>Center-of</value>
+                  <value>Lower-center-of</value>
                   <value>Lower-left-of</value>
                   <value>Upper-left-of</value>
+                  <value>Upper-center-of</value>
                   <value>Lower-right-of</value>
                </attribute>
             </node>
@@ -5836,7 +5894,7 @@
          </node>
          <node>
             <name>Temporal-relation</name>
-            <description>Any relationship which includes a temporal or time-based component.</description>
+            <description>A relationship that includes a temporal or time-based component.</description>
             <node>
                <name>After</name>
                <description>(A, (After B)) means A happens at a time subsequent to a reference time related to B.</description>
@@ -6912,6 +6970,13 @@
          </property>
          <property>
             <name>unitModifierProperty</name>
+         </property>
+      </schemaAttributeDefinition>
+      <schemaAttributeDefinition>
+         <name>deprecated</name>
+         <description>This tag is out of date and should no longer be used.</description>
+         <property>
+            <name>boolProperty</name>
          </property>
       </schemaAttributeDefinition>
       <schemaAttributeDefinition>


### PR DESCRIPTION
Missing parentheses in description for `Performed-using`.  Corrected in prerelease 8.2.0.  Does not affect tagging or processing of HED tags. 

@robertoostenveld Thx