### PR TITLE
Attempt #2: Add codespell support (config, workflow to detect/not fix) and make it fix few typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+skip = .git,*.pdf,*.svg
+#
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = .git,*.pdf,*.svg,deprecated
-ignore-words-list = covert
+ignore-words-list = covert,hed

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,3 @@
 [codespell]
-skip = .git,*.pdf,*.svg
-#
-# ignore-words-list =
+skip = .git,*.pdf,*.svg,deprecated
+ignore-words-list = covert

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-skip = .git,*.pdf,*.svg,deprecated
+skip = .git,*.pdf,*.svg,deprecated,*.xml,*.mediawiki,*.omn
 ignore-words-list = covert,hed

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,22 @@
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -17,6 +17,6 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -3,9 +3,9 @@ name: Codespell
 
 on:
   push:
-    branches: [master]
+    branches: [master,develop]
   pull_request:
-    branches: [master]
+    branches: [master,develop]
 
 permissions:
   contents: read

--- a/docs/source/02_Terminology.md
+++ b/docs/source/02_Terminology.md
@@ -150,7 +150,7 @@ The types of characters referred to in this specification are:
 | `lowercase` | ASCII characters a-z |  
 | `uppercase` | ASCII characters A-Z |
 | `letters` | `lowercase` and/or `uppercase` |
-| `text` | `printable` and/or `nonascii` exluding comma, square brackets, and curly braces.|
+| `text` | `printable` and/or `nonascii` excluding comma, square brackets, and curly braces.|
 | `digits` | 0-9 |
 | `tab` | ASCII code 09 |
 | `newline` | ASCII code 10 (linefeed) |

--- a/docs/source/03_HED_formats.md
+++ b/docs/source/03_HED_formats.md
@@ -1215,7 +1215,7 @@ and whose names do not appear in the curly braces of other HED annotations.
 3. For each the column in the assembly list look up the annotation in the sidecar, replacing all curly braces and place holder values appropriately.
 Append to the result list.
 4. If a `HED` column annotation exists for that row and `HED` did not appear
-in curly braces in the sidecar, concatentate the annotation to the result list.
+in curly braces in the sidecar, concatenate the annotation to the result list.
 5. Finally, join all the entries of the result list using a comma (`,`) separator.
 
 In all cases `n/a` column values are skipped.

--- a/docs/source/05_Advanced_annotation.md
+++ b/docs/source/05_Advanced_annotation.md
@@ -306,7 +306,7 @@ playing of different clips.
 > *Data-property/Data-marker/Temporal-marker/<strong>Onset</strong>,*  
 > *(Property/Informational-property/<strong>Label/StarWars</strong>,*  
 > *(Item/Object/Man-made-object/Media/<strong>Media-clip</strong>,*  
-> *Properity/Informational-property/<strong>ID/3284</strong>)))*  
+> *Property/Informational-property/<strong>ID/3284</strong>)))*  
             
 >         .... [The Star Wars movie clip is playing] ....
 

--- a/docs/source/07_Library_schemas.md
+++ b/docs/source/07_Library_schemas.md
@@ -311,7 +311,7 @@ error is generated.
 **Note:** With the possible (and rare) exception of new `unitClasses` and `units`, partnered library schemas 
 should not have auxiliary sections except for the `prologue` and `epilogue`.  
 
-Auxilliary sections have information for HED tools, and new entries may require modification to
+Auxiliary sections have information for HED tools, and new entries may require modification to
 schema validation tools.  
 
 If a new entry is needed, contact the HED Working Group (hed.maintainers@gmail.com) to see if the
@@ -336,7 +336,7 @@ This section summarizes the general design rules for all library schema.
 :class: tip
 
 1. **Follow naming conventions**:<br/>
-A library schema must be given a name containing only alphabetic chararacters.
+A library schema must be given a name containing only alphabetic characters.
 This name must appear in the schema header line in the required format.
 <br>&nbsp;</br>
 2. **Use semantic versioning**:<br/>

--- a/docs/source/08_HED_ontology.md
+++ b/docs/source/08_HED_ontology.md
@@ -219,7 +219,7 @@ The following table summarizes how the HED schema and HED ontology are mapped.
   - * Defined in the `Unit Modifiers` section of the HED schema.
     * Usually only defined in the standard schema
     * Defining schemas must define a class extending `HedUnitModifier` (`heds:HED_0000008`).
-    * Unit modifers in the standard schema inherit from `StandardUnitModifier` (`HED_0010008`).
+    * Unit modifiers in the standard schema inherit from `StandardUnitModifier` (`HED_0010008`).
 * - **Value class** 
   - * Defined in the `Value classes` section of the HED schema.
     * Usually only defined in the standard schema.

--- a/docs/source/Appendix_A.md
+++ b/docs/source/Appendix_A.md
@@ -238,7 +238,7 @@ Only the schema attributes listed in the following table can be handled by curre
   - Range
   - Description  
 * - [`allowedCharacter`](#a141-allowedcharacter)  
-  - unit<br/>unit modifer<br/>value class  
+  - unit<br/>unit modifier<br/>value class  
   - string
   - Specifies a character used in values of this class.  
 * - [`conversionFactor`](#a142-conversionfactor)


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe

Prior attempt was reverted in 

- https://github.com/hed-standard/hed-specification/pull/549

so may be there is something to skip/do differently?  But IMHO it is worth to ensure that there is no typos, especially in a standard where words define it ;-)
