### PR TITLE
Updated the tests to account for missing HED column

### DIFF
--- a/docs/source/Appendix_B.md
+++ b/docs/source/Appendix_B.md
@@ -179,6 +179,7 @@ general explanation of sidecar requirements.
 (WARNING) 
 
 **a.**  A value in a categorical column does not have an expected entry in a sidecar.    
+**b.**  A {ref} in a sidecar does not correspond to a column in the associated tabular file.  
 
 **Note:** This warning is only triggered if the categorical column in which the value
 appears does have HED annotations.

--- a/tests/javascriptTests.json
+++ b/tests/javascriptTests.json
@@ -4425,6 +4425,14 @@
                     {
                         "event_code": {
                             "HED": {
+                                "face": "{HED}",
+                                "ball": "Red"
+                            }
+                        }
+                    },
+                    {
+                        "event_code": {
+                            "HED": {
                                 "face": "(Red, Blue), (Green, (Yellow))",
                                 "ball": "{HED}, (Def/Acc/3.5, {response_action})"
                             }
@@ -4543,6 +4551,36 @@
                                 "7,3",
                                 "face",
                                 "n/a"
+                            ]
+                        ]
+                    },
+                    {
+                        "sidecar": {
+                            "event_code": {
+                                "HED": {
+                                    "face": "{HED}",
+                                    "ball": "Red"
+                                }
+                            }
+                        },
+                        "events": [
+                            [
+                                "onset",
+                                "duration",
+                                "response_time",
+                                "event_code"
+                            ],
+                            [
+                                4.5,
+                                0,
+                                3.4,
+                                "face"
+                            ],
+                            [
+                                5.0,
+                                0,
+                                6.8,
+                                "ball"
                             ]
                         ]
                     }
@@ -5061,6 +5099,104 @@
                                 0,
                                 "ball",
                                 "Green, Def/MyColor"
+                            ]
+                        ]
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "error_code": "SIDECAR_KEY_MISSING",
+        "alt_codes": [],
+        "name": "sidecar-refers-to-missing-tsv-hed-column",
+        "description": "(Warning) A sidecar uses a {HED} column which does not appear in the corresponding tsv file.",
+        "warning": true,
+        "schema": "8.3.0",
+        "definitions": [
+            "(Definition/Acc/#, (Acceleration/# m-per-s^2, Red))",
+            "(Definition/MyColor, (Label/Pie))"
+        ],
+        "tests": {
+            "string_tests": {
+                "fails": [],
+                "passes": []
+            },
+            "sidecar_tests": {
+                "fails": [],
+                "passes": [
+                    {
+                        "event_code": {
+                            "HED": {
+                                "face": "{HED}",
+                                "ball": "Red"
+                            }
+                        }
+                    }
+                ]
+            },
+            "event_tests": {
+                "fails": [],
+                "passes": []
+            },
+            "combo_tests": {
+                "fails": [
+                    {
+                        "sidecar": {
+                            "event_code": {
+                                "HED": {
+                                    "face": "{HED}",
+                                    "ball": "Red"
+                                }
+                            }
+                        },
+                        "events": [
+                            [
+                                "onset",
+                                "duration",
+                                "event_code"
+                            ],
+                            [
+                                4.5,
+                                0,
+                                "face"
+                            ],
+                            [
+                                5.0,
+                                0,
+                                "ball"
+                            ]
+                        ]
+                    }
+                ],
+                "passes": [
+                    {
+                        "sidecar": {
+                            "event_code": {
+                                "HED": {
+                                    "face": "{HED}",
+                                    "ball": "Red"
+                                }
+                            }
+                        },
+                        "events": [
+                            [
+                                "onset",
+                                "duration",
+                                "event_code",
+                                "HED"
+                            ],
+                            [
+                                4.5,
+                                0,
+                                "face",
+                                "Green"
+                            ],
+                            [
+                                5.0,
+                                0,
+                                "ball",
+                                "Black"
                             ]
                         ]
                     }

--- a/tests/json_tests/SIDECAR_BRACES_INVALID.json
+++ b/tests/json_tests/SIDECAR_BRACES_INVALID.json
@@ -323,6 +323,14 @@
                     {
                         "event_code": {
                             "HED": {
+                                "face": "{HED}",
+                                "ball": "Red"
+                            }
+                        }
+                    },
+                    {
+                        "event_code": {
+                            "HED": {
                                 "face": "(Red, Blue), (Green, (Yellow))",
                                 "ball": "{HED}, (Def/Acc/3.5, {response_action})"
                             }
@@ -386,6 +394,22 @@
                                 [ 5.0, 0, 6.8, "ball", "Green, Def/MyColor"],
                                 [ 5.2, 0, "n/a", "face", ""],
                                 [ 5.5, 0, "7,3", "face", "n/a"]
+                            ]
+                    },
+                    {
+                        "sidecar":  {
+                            "event_code": {
+                                "HED": {
+                                    "face": "{HED}",
+                                    "ball": "Red"
+                                }
+                            }
+                        },
+                        "events":
+                            [
+                                ["onset", "duration", "response_time", "event_code"],
+                                [ 4.5, 0, 3.4, "face"],
+                                [ 5.0, 0, 6.8, "ball"]
                             ]
                     }
                 ]

--- a/tests/json_tests/SIDECAR_KEY_MISSING.json
+++ b/tests/json_tests/SIDECAR_KEY_MISSING.json
@@ -65,5 +65,108 @@
                 ]
             }
         }
+    },
+    {
+        "error_code": "SIDECAR_KEY_MISSING",
+        "alt_codes": [],
+        "name": "sidecar-refers-to-missing-tsv-hed-column",
+        "description": "(Warning) A sidecar uses a {HED} column which does not appear in the corresponding tsv file.",
+        "warning": true,
+        "schema": "8.3.0",
+        "definitions": [
+            "(Definition/Acc/#, (Acceleration/# m-per-s^2, Red))",
+            "(Definition/MyColor, (Label/Pie))"
+        ],
+        "tests": {
+            "string_tests": {
+                "fails": [
+                ],
+                "passes": [
+                ]
+            },
+            "sidecar_tests": {
+                "fails": [
+                ],
+                "passes": [
+                    {
+                        "event_code": {
+                            "HED": {
+                               "face": "{HED}",
+                               "ball": "Red"
+                            }
+                        }
+                    }
+                ]
+            },
+            "event_tests": {
+                "fails": [
+                ],
+                "passes": [
+                ]
+            },
+            "combo_tests": {
+                "fails": [
+                    {
+                        "sidecar": {
+                            "event_code": {
+                                "HED": {
+                                    "face": "{HED}",
+                                    "ball": "Red"
+                                }
+                            }
+                        },
+                        "events": [
+                            [
+                                "onset",
+                                "duration",
+                                "event_code"
+                            ],
+                            [
+                                4.5,
+                                0,
+                                "face"
+                            ],
+                            [
+                                5.0,
+                                0,
+                                "ball"
+                            ]
+                        ]
+                    }
+                ],
+                "passes": [
+                    {
+                        "sidecar": {
+                            "event_code": {
+                                "HED": {
+                                    "face": "{HED}",
+                                    "ball": "Red"
+                                }
+                            }
+                        },
+                        "events": [
+                            [
+                                "onset",
+                                "duration",
+                                "event_code",
+                                "HED"
+                            ],
+                            [
+                                4.5,
+                                0,
+                                "face",
+                                "Green"
+                            ],
+                            [
+                                5.0,
+                                0,
+                                "ball",
+                                "Black"
+                            ]
+                        ]
+                    }
+                ]
+            }
+        }
     }
 ]    


### PR DESCRIPTION
This should be a warning not an error (when {HED} in sidecar but no HED column in tsv).