### PR TITLE
Adopt standard repo layout: AGENTS.md as the single instruction source

### DIFF
--- a/.claude/rules/status_conduct.md
+++ b/.claude/rules/status_conduct.md
@@ -1,0 +1,23 @@
+---
+paths:
+  - ".status/**"
+---
+
+# Working in .status/
+
+- `.status/` is gitignored: the only copy is on this machine. Never delete,
+  move, or rewrite a file here without asking first. Appending is fine.
+- Every markdown file written here opens with a `For humans:` summary - three
+  or four sentences at the very top: what the file is and what a person needs
+  to take from it.
+- Nothing new is created at the `.status/` root. New material goes in
+  `plans/`, `prompts/`, `notes/`, or `scratch/`.
+- Only `plans/` and `prompts/` are edited in place. `notes/` is write-once.
+  `decisions.md` is append-only - never rewrite an entry.
+- Temporary scripts, experiments, and one-off test files go in
+  `.status/scratch/` - never the repository root. `scratch/` may hold any
+  file type and is deleted unread; everywhere else is markdown only.
+- Do not read `archive/` unless a file is named for you.
+- Filenames: lowercase ASCII, `_` as separator. Notes are
+  `YYYY-MM-DD_slug.md` (date first); plans and prompts are `slug.md` - no
+  date, no status word in the name.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+
+  "permissions": {
+    "allow": [
+      "Bash(python -m ruff *)",
+      "Bash(python -m mdformat *)",
+      "Bash(python -c *)",
+      "Bash(python --version)",
+      "Bash(sphinx-build *)",
+      "Bash(uvx typos*)",
+      "Bash(uvx --with mdformat-myst mdformat --check *)",
+      "Bash(git status)",
+      "Bash(git status *)",
+      "Bash(git log)",
+      "Bash(git log *)",
+      "Bash(git diff)",
+      "Bash(git diff *)",
+      "Bash(git show *)",
+      "Bash(git branch)",
+      "Bash(git ls-files *)",
+      "Bash(grep *)",
+      "Bash(ls)",
+      "Bash(ls *)",
+      "Bash(head *)",
+      "Bash(tail *)",
+      "Bash(cat *)",
+      "Bash(wc *)"
+    ],
+
+    "ask": [
+      "Bash(git add *)",
+      "Bash(git commit *)",
+      "Bash(git checkout -- *)",
+      "Bash(git restore *)",
+      "Bash(git stash *)"
+    ],
+
+    "deny": [
+      "Read(.env)",
+      "Read(.envrc)",
+      "Read(.status/archive/**)",
+      "Bash(rm -rf *)",
+      "Bash(rm -r *)",
+      "Bash(git push)",
+      "Bash(git push *)",
+      "Bash(git reset --hard *)",
+      "Bash(pip install *)",
+      "Bash(python -m pip install *)",
+      "Bash(curl *)",
+      "Bash(wget *)"
+    ]
+  }
+}

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,146 +1,18 @@
-# HED-specification developer instructions
+# hed-specification
 
-If a `.status/local-environment.md` file exists in the repository root, read it first. It contains machine-specific settings (OS, shell, virtual-environment activation) that override the defaults below.
+**`AGENTS.md` at the repository root is the instruction set for this project.
+Read it before answering, and follow it.**
 
-Trust these instructions. Only search the repo for additional context when the information here is incomplete or appears incorrect.
+This file is a pointer and duplicates nothing. One source, several pointers: a
+rule stated in two files is a rule that will disagree with itself.
 
-## Repository overview
+Path-specific instructions live in `.github/instructions/*.instructions.md`
+and load automatically when the files being worked on match their `applyTo`
+glob - for example, `status_conduct.instructions.md` applies under `.status/`.
+Nothing needs to reference them; this note exists so a reader knows they are
+there.
 
-This is a **documentation-only** repository that manages the HED (Hierarchical Event Descriptors) ecosystem specification. It contains no runtime Python packages — only Sphinx/MyST markdown source files, official PDF releases, reference XML schemas, and JSON test cases for HED validators.
-
-- **Specification version**: 4.0.0
-- **Target HED schema versions**: ≥ 8.0.0 (HED-3G)
-- **Documentation framework**: Sphinx 7+ with MyST parser, Furo theme
-- **Python**: ≥ 3.10 (used only for building docs and running quality tools)
-- **Output**: HTML (GitHub Pages via Sphinx) and PDF (in `hedspec/`)
-
-## Project layout
-
-| Path                 | Purpose                                                                                               |
-| -------------------- | ----------------------------------------------------------------------------------------------------- |
-| `docs/source/`       | Sphinx/MyST markdown spec chapters (`01_Introduction.md` … `Appendix_B.md`), `conf.py`, static assets |
-| `hedspec/`           | Official PDF specification releases (do **not** modify)                                               |
-| `hedxml/`            | Reference HED schema XML files (do **not** modify)                                                    |
-| `tests/`             | JSON test cases keyed by error code                                                                   |
-| `.status/`           | Local analysis scripts and summaries (gitignored)                                                     |
-| `pyproject.toml`     | Project metadata and `[dev]` dependencies                                                             |
-| `lychee.toml`        | Link-checker configuration                                                                            |
-| `.github/workflows/` | CI pipelines (see below)                                                                              |
-
-## Build and validation
-
-### Line endings configuration
-
-This repository is configured to use Unix-style line endings (`\n`, LF) across all platforms.
-
-#### Git configuration
-
-- **`.gitattributes`**: Explicitly sets `* text=auto eol=lf` to normalize all text files to LF line endings on commit
-- **Global Git config**: `core.autocrlf=false` and `core.eol=lf` (prevents automatic CRLF conversion on Windows)
-
-#### VS Code settings
-
-The `.vscode/settings.json` is configured with:
-
-```json
-{
-    "files.eol": "\n",
-    "files.insertFinalNewline": true,
-    "files.trimTrailingWhitespace": true
-}
-```
-
-This ensures:
-
-- New files created in VS Code use LF line endings
-- Files always end with a newline (required by CI checks)
-- Trailing whitespace is automatically cleaned up
-
-### Bootstrap (one time)
-
-```bash
-uv venv --clear .venv          # or: python -m venv .venv
-# activate the venv (see local-environment.md for platform-specific command)
-uv pip install -e ".[dev]"     # or: pip install -e ".[dev]"
-```
-
-### Build documentation
-
-```bash
-sphinx-build -b html docs/source docs/_build/html
-```
-
-### Local quality checks (run before pushing)
-
-Always run these — they mirror the CI pipelines and catch failures early.
-
-| Check               | Command                                                                            |
-| ------------------- | ---------------------------------------------------------------------------------- |
-| Spelling (typos)    | `uvx typos`                                                                        |
-| Markdown formatting | `uvx --with mdformat-myst mdformat --check --wrap no --number docs/source *.md`    |
-| Link checking       | Build docs first, then: `lychee --config lychee.toml 'docs/_build/html/**/*.html'` |
-
-### CI pipelines (`.github/workflows/`)
-
-Every push and PR to `main` runs these checks automatically:
-
-| Workflow             | File              | What it checks                                                  |
-| -------------------- | ----------------- | --------------------------------------------------------------- |
-| Deploy documentation | `deploy-docs.yml` | Sphinx build succeeds                                           |
-| Typos                | `typos.yaml`      | No typos (`uvx typos`, config in `pyproject.toml [tool.typos]`) |
-| Mdformat             | `mdformat.yaml`   | Markdown formatting compliance                                  |
-| Lychee link checker  | `links.yaml`      | No broken links (weekly schedule + manual)                      |
-
-## Markdown style
-
-- **Heading case**: Use sentence case — capitalize only the first letter of the first word (and proper nouns). Example: `## Build and validation`, not `## Build and Validation`.
-- Use proper heading hierarchy (`#` for chapters, `##` for sections, `###` for subsections).
-- Use code blocks with the `hed` language tag for HED annotation examples.
-- Markdown files must pass `mdformat --check --wrap no --number`.
-
-## HED annotation conventions
-
-- Tags are case-sensitive and use `/` for hierarchy (e.g., `Sensory-event/Visual/Color/Red`).
-- Groups use parentheses: `(Onset, Sensory-event, (Circle, Blue))`.
-- Definitions allow reusable annotation patterns with placeholders.
-- Library schemas extend the standard schema with domain-specific vocabulary.
-- Use backticks for inline HED tags; use fenced code blocks for multi-line examples.
-- Show both short form (`Red`) and long form when helpful.
-
-## Key principles
-
-### Documentation standards
-
-- Write in clear, technical language for tool implementers and advanced users.
-- Use precise terminology defined in `02_Terminology.md`.
-- Cross-reference related sections using markdown links.
-- Always specify which specification version introduces or modifies features.
-- Distinguish between specification version (4.x.x) and schema version (8.x.x).
-
-### Code and testing standards
-
-- Python code follows PEP 8; use `ruff` for linting.
-- Test files use JSON: `{"error_code": {"description": "...", "tests": {"valid": [...], "invalid": [...]}}}`.
-- Use standardized error codes (e.g., `CHARACTER_INVALID`, `COMMA_MISSING`) as listed in `Appendix_B.md`. Add new error codes there following the existing format.
-- Use `pathlib.Path` for file paths; use type hints and docstrings in Python scripts.
-
-### Cross-references
-
-- Link to other chapters: `[Chapter 4: Basic annotation](04_Basic_annotation.md)`
-- Link to sections: `[See Definition syntax](#45-definition-syntax)`
-- Link to external HED resources with full URLs
-
-## Avoid
-
-- Don't modify files in `hedspec/` or `hedxml/`.
-- Don't introduce breaking changes to the test JSON format without discussion.
-- Don't use ambiguous or informal language in specification documentation.
-- Don't mix specification features with implementation details.
-
-## Related resources
-
-- [HED specification](https://www.hedtags.org/hed-specification)
-- [HED resources](https://www.hedtags.org/hed-resources)
-- [HED schemas repository](https://github.com/hed-standard/hed-schemas)
-- [HED standard organization](https://github.com/hed-standard)
-- [HED tags website](https://www.hedtags.org)
+Machine-specific facts - interpreter, local paths, cache locations - are in
+`.status/local-environment.md`, which is gitignored: read it when it is there
+and ignore its absence when it is not. No committed file in this repository
+may contain a local path or a drive letter.

--- a/.github/instructions/status_conduct.instructions.md
+++ b/.github/instructions/status_conduct.instructions.md
@@ -1,0 +1,22 @@
+---
+applyTo: ".status/**"
+---
+
+# Working in .status/
+
+- `.status/` is gitignored: the only copy is on this machine. Never delete,
+  move, or rewrite a file here without asking first. Appending is fine.
+- Every markdown file written here opens with a `For humans:` summary - three
+  or four sentences at the very top: what the file is and what a person needs
+  to take from it.
+- Nothing new is created at the `.status/` root. New material goes in
+  `plans/`, `prompts/`, `notes/`, or `scratch/`.
+- Only `plans/` and `prompts/` are edited in place. `notes/` is write-once.
+  `decisions.md` is append-only - never rewrite an entry.
+- Temporary scripts, experiments, and one-off test files go in
+  `.status/scratch/` - never the repository root. `scratch/` may hold any
+  file type and is deleted unread; everywhere else is markdown only.
+- Do not read `archive/` unless a file is named for you.
+- Filenames: lowercase ASCII, `_` as separator. Notes are
+  `YYYY-MM-DD_slug.md` (date first); plans and prompts are `slug.md` - no
+  date, no status word in the name.

--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,9 @@ Thumbs.db
 
 # Folder config file
 Desktop.ini
+
+# Personal per-repo Claude Code notes (imports .status/local-environment.md)
+CLAUDE.local.md
+
+# Personal per-repo settings (absolute paths, claudeMdExcludes)
+.claude/settings.local.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
   "files.eol": "\n",
   "files.insertFinalNewline": true,
-  "files.trimTrailingWhitespace": true
+  "files.trimTrailingWhitespace": true,
+  "python.testing.pytestEnabled": false,
+  "python.testing.unittestEnabled": false
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,69 @@
+# hed-specification
+
+Purpose: source of the HED (Hierarchical Event Descriptors) specification - Sphinx/MyST markdown chapters published as HTML via GitHub Pages. Not in scope: no runtime Python package, no test suite, and no schema files - HED schemas live in the `hed-schemas` repository.
+
+## Commands
+
+Test framework: none (documentation-only repository; no test suite).
+
+- Install dev env: `uv venv --clear .venv` then `uv pip install -e ".[dev]"` (or the plain `python -m venv` / `pip install` equivalents)
+- Build docs: `sphinx-build -b html docs/source docs/_build/html`
+- Spelling: `uvx typos`
+- Markdown format check: `uvx --with mdformat-myst mdformat --check --wrap no --number docs/source *.md`
+- Link check (after building docs): `lychee --config lychee.toml 'docs/_build/html/**/*.html'`
+
+CI runs the same checks on every push and PR to `main` (`.github/workflows/`): deploy-docs.yml (Sphinx build), typos.yaml, mdformat.yaml, and links.yaml (weekly schedule plus manual).
+
+## Layout
+
+- `docs/source/` - the spec chapters (`01_Introduction.md` ... `Appendix_B.md`), `conf.py`, and static assets. This is the content of the repository.
+- `.github/workflows/` - CI pipelines listed above.
+- `pyproject.toml` - project metadata, `[dev]` dependencies, typos config.
+- `lychee.toml` - link-checker configuration.
+- `.status/` - working notes. Gitignored; local to each machine.
+
+## Conventions that differ from defaults
+
+- **ASCII only** in prose, code, comments, and filenames: `-` not em or en dashes, `->` not arrows, `...` not an ellipsis character, straight quotes. Exception: genuine data (author names, dataset titles, recorded API responses) keeps whatever characters it actually contains.
+- Markdown headers in sentence case: capitalize the first word, proper nouns, and acronyms only (`## Build and validation`, not `## Build and Validation`).
+- Line endings are LF everywhere; `.gitattributes` normalizes on commit and `.vscode/settings.json` on save. Files always end with a newline.
+- Markdown must pass `mdformat --check --wrap no --number`.
+- Use proper heading hierarchy: `#` chapters, `##` sections, `###` subsections.
+
+## HED annotation conventions
+
+- Tags are case-sensitive and use `/` for hierarchy (`Sensory-event/Visual/Color/Red`); groups use parentheses: `(Onset, Sensory-event, (Circle, Blue))`.
+- Use backticks for inline HED tags and fenced code blocks with the `hed` language tag for multi-line examples; show short form (`Red`) and long form together when helpful.
+- Use precise terminology as defined in `docs/source/02_Terminology.md`, and distinguish the specification version (owned by `pyproject.toml`) from the HED schema version (8.x.x).
+- Always state which specification version introduces or modifies a feature.
+- Use standardized error codes (`CHARACTER_INVALID`, `COMMA_MISSING`, ...) as listed in `docs/source/Appendix_B.md`; add new codes there in the existing format.
+
+## Rules that are easy to get wrong
+
+- Cross-reference chapters with relative markdown links (`[Chapter 4: Basic annotation](04_Basic_annotation.md)`) and sections with anchors (`[See Definition syntax](#45-definition-syntax)`).
+- Write for tool implementers: no ambiguous or informal language, and keep specification statements separate from implementation details.
+
+## Related repositories
+
+- `hed-schemas` - the HED schema XML/mediawiki sources this spec describes. Not vendored here; a session that needs it must be granted access to that checkout.
+- `hed-resources` - user-facing documentation and tutorials.
+
+## Where the thinking lives
+
+`.status/` is gitignored, so it exists only on the machine that wrote it and never in a fresh clone or worktree.
+
+- `.status/README.md` - the index. Read this first; it lists what is active.
+- `.status/decisions.md` - why things are the way they are. Read before proposing structural changes. Append entries; never rewrite one.
+- `.status/plans/*.md` - active plans. Check the `Status:` header and the `[ ]` / `[x]` markers before starting work.
+- `.status/local-environment.md` - this machine's paths, interpreter, and quirks. Tool-agnostic. Never copy its contents into a committed file.
+- IMPORTANT: do not read `.status/archive/` unless a file is named for you. Nothing new is created at the `.status/` root.
+
+## Working agreements
+
+- IMPORTANT: every file written to `.status/` opens with a `For humans:` summary - three or four sentences, at the very top: what the file is and what a person needs to take from it. The same applies to a long answer in a session: lead with the conclusion.
+- IMPORTANT: temporary scripts, experiments, and one-off test files go in `.status/scratch/` - **never the repository root**. Delete them when the experiment ends; anything in `scratch/` may be deleted unread.
+- IMPORTANT: never delete or rewrite a file under `.status/` without asking first. Appending is fine.
+- For a change spanning more than three files, write a plan to `.status/plans/` and stop for review before editing.
+- When you are guessing about an external API or data format, say so explicitly rather than assuming.
+- Show evidence, not assertions: the command you ran and its actual output.
+- Do not commit, push, or create branches unless asked.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+@AGENTS.md
+
+# Claude Code
+
+- Path-scoped rules live in `.claude/rules/` and load automatically when a session touches files matching their `paths:` globs - for example, `status_conduct.md` applies under `.status/`. Nothing needs to reference them; this note exists so a reader knows they are there.
+- `CLAUDE.local.md` (gitignored) holds notes about this machine's Claude Code setup and imports `.status/local-environment.md`, which is where machine facts live for every tool, not just this one.
+- After changing either import, run `/context` and confirm the file appears under **Memory files**.


### PR DESCRIPTION
AGENTS.md is now the instruction file for all assistants; CLAUDE.md imports it and .github/copilot-instructions.md is reduced to a pointer. Adds .claude/settings.json (permissions), the status_conduct rule pair, vscode testing keys, and gitignore entries for personal local files.